### PR TITLE
Add OG image JPG and remove duplicate author section

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,10 +105,6 @@ A arquitetura já está ~80% preparada para escalar. O `DataStore` é agnóstico
 | Média | Compartilhamento de intervalos de mensagens | Não iniciado |
 | Baixa | Otimização para 100+ conversas (paginação, cache namespacing) | Não iniciado |
 
-## Autor
-
-Feito por **[Rafael Bressan](https://linkedin.com/in/rafaelbressan)** com **[Claude Code](https://claude.ai/code)**.
-
 ## Aviso Legal
 
 As informações compiladas neste projeto são de domínio público, extraídas de reportagens jornalísticas e fontes abertas. Este projeto não tem vinculação com nenhuma das partes envolvidas.


### PR DESCRIPTION
## Summary
- Convert `og-image.png` (transparent) to `og-image.jpg` (white background) for README cover
- Update README to reference the JPG version
- Remove duplicate "Autor" section from bottom of README (already present at top)

https://claude.ai/code/session_01TpdB6gkqdmconvTjmpyjim