### PR TITLE
SEO: o site conta os dois vazamentos, não só o da Martha

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # MasterWhats
 
-> Visualizador interativo das 65.772 mensagens de WhatsApp vazadas entre Daniel Vorcaro (Banco Master) e Martha Graeff.
+> Visualizador interativo das 66.387 mensagens de WhatsApp extraídas dos celulares apreendidos de Daniel Vorcaro (Banco Master), em 24 conversas — de Martha Graeff a Alexandre de Moraes.
 
 **[Acesse ao vivo: www.masterwhats.com.br](https://www.masterwhats.com.br/)**
 
@@ -13,9 +13,12 @@ Feito por **[Rafael Bressan](https://linkedin.com/in/rafaelbressan)** com **[Cla
 
 ## Sobre o Projeto
 
-Em março de 2026, mensagens de WhatsApp extraídas do celular apreendido de Daniel Vorcaro — ex-dono do Banco Master, preso pela Polícia Federal — foram vazadas para a imprensa. As 65.772 mensagens trocadas com sua então namorada Martha Graeff revelaram conexões com autoridades dos Três Poderes, apelidos carinhosos que viralizaram nas redes e detalhes do maior escândalo bancário da história do Brasil.
+As mensagens vêm dos celulares apreendidos de Daniel Vorcaro — ex-dono do Banco Master, preso pela Polícia Federal em novembro de 2025 — e chegaram ao público em dois momentos, por caminhos diferentes:
 
-O MasterWhats transforma essas conversas em uma experiência de leitura no estilo WhatsApp Web: navegável, pesquisável e compartilhável.
+- **Março de 2026 — as conversas com Martha Graeff.** 65.772 mensagens trocadas com a então noiva vazaram para a imprensa e revelaram conexões com autoridades dos Três Poderes, apelidos que viralizaram nas redes e detalhes do maior escândalo bancário da história do Brasil.
+- **Setembro de 2026 — o relatório da PF sobre Alexandre de Moraes.** Caiu o sigilo da IPJ-A nº 3298613/2026, em que a Polícia Federal reconstrói, a partir do iPhone de Vorcaro, seus contatos com o ministro do STF e outras 22 pessoas. Não é um export de WhatsApp: as mensagens estavam em imagens dentro do laudo e foram transcritas uma a uma — veja [`data/ipj-3298613/README.md`](data/ipj-3298613/README.md).
+
+O MasterWhats transforma essas conversas em uma experiência de leitura no estilo WhatsApp Web: navegável, pesquisável e compartilhável. Cada contato tem um perfil que explica quem é a pessoa, o que o material revela e de onde vem a informação. Um novo vazamento entra como mais uma conversa.
 
 ### Origem do nome
 
@@ -37,7 +40,7 @@ O nome do repositório — **masterzap** — é uma referência ao projeto origi
 |-------|---------|
 | **Frontend** | Vanilla JS — zero frameworks |
 | **Build** | Vite |
-| **Dados** | 65.772 mensagens divididas em arquivos JSON por data |
+| **Dados** | 66.387 mensagens em 24 conversas, divididas em arquivos JSON por data |
 | **Carregamento** | Lazy loading com cache LRU por dia |
 | **Deploy** | Vercel com headers de segurança (HSTS, CSP, X-Frame-Options) |
 | **SEO** | Open Graph, Twitter Cards, JSON-LD, sitemap |
@@ -75,8 +78,8 @@ tests/e2e/            # Testes E2E (Playwright)
 
 ## Limitações Conhecidas
 
-- **Apenas mensagens de texto** — imagens, áudios, vídeos, stickers e documentos não foram incluídos no vazamento. As mensagens de mídia aparecem com placeholder indicando o tipo de conteúdo.
-- **Uma conversa** — atualmente apenas as mensagens entre Vorcaro e Martha Graeff estão disponíveis. A arquitetura já suporta múltiplas conversas (veja o roadmap).
+- **Apenas mensagens de texto** — imagens, áudios, vídeos, stickers e documentos não foram incluídos nos vazamentos. As mensagens de mídia aparecem com placeholder indicando o tipo de conteúdo.
+- **Conversas do relatório da PF são trechos** — exceto a de Alexandre de Moraes, as outras 22 aparecem no laudo apenas nos pontos que a PF citou; a conversa completa não consta do documento.
 
 Se novas mídias ou conversas se tornarem públicas, o projeto está preparado para incorporá-las.
 
@@ -98,8 +101,8 @@ A arquitetura já está ~80% preparada para escalar. O `DataStore` é agnóstico
 
 | Prioridade | Item | Status |
 |------------|------|--------|
-| Alta | Suporte a múltiplas conversas vazadas | Arquitetura pronta, ajustes no search e main.js |
-| Alta | Cache de índice de busca por conversa | Módulo de busca usa estado global — precisa refatorar |
+| Alta | Suporte a múltiplas conversas vazadas | Feito — 24 conversas de duas fontes |
+| Alta | Cache de índice de busca por conversa | Feito — cache por conversa |
 | Média | Busca cruzada entre conversas | Não iniciado |
 | Média | Suporte a mídias (imagens, áudio, vídeo) | Aguardando disponibilidade do conteúdo |
 | Média | Compartilhamento de intervalos de mensagens | Não iniciado |
@@ -113,10 +116,10 @@ As informações compiladas neste projeto são de domínio público, extraídas 
 
 ## English Summary
 
-**MasterWhats** is an interactive viewer for 65,772 leaked WhatsApp messages between Daniel Vorcaro (former owner of Banco Master, arrested by Brazil's Federal Police) and Martha Graeff. Built with vanilla JS and Vite, it features smart search with accent support, calendar navigation, direct message link sharing, investigative profiles, and a fully responsive WhatsApp Web-like interface optimized for mobile.
+**MasterWhats** is an interactive viewer for 66,387 WhatsApp messages recovered from the seized phones of Daniel Vorcaro (former owner of Banco Master, arrested by Brazil's Federal Police), across 24 conversations: the leaked exchanges with Martha Graeff and the Federal Police report on his contacts with Supreme Court Justice Alexandre de Moraes, unsealed in September 2026. Built with vanilla JS and Vite, it features smart search with accent support, calendar navigation, direct message link sharing, investigative profiles, and a fully responsive WhatsApp Web-like interface optimized for mobile.
 
 The repo name "masterzap" references the original [MasterZap](https://www.reddit.com/r/brasil/s/xQeqrG27p8) project by Lucas Matheus (built on Replit with Grok), which inspired this reimagined version.
 
-**Contributions welcome** — new leaked conversations, media support, sharing improvements, and bug fixes. See the Roadmap section above. Only text messages are currently available; images, audio, and video were not part of the leak.
+**Contributions welcome** — new leaked conversations, media support, sharing improvements, and bug fixes. See the Roadmap section above. Only text messages are currently available; images, audio, and video were not part of the leaks.
 
 **[Live: www.masterwhats.com.br](https://www.masterwhats.com.br/)** | **Author: [Rafael Bressan](https://linkedin.com/in/rafaelbressan)**

--- a/index.html
+++ b/index.html
@@ -6,15 +6,15 @@
   <title>MasterWhats — Conversas Vazadas de Daniel Vorcaro</title>
 
   <!-- SEO -->
-  <meta name="description" content="Visualizador interativo das 65 mil mensagens vazadas entre Daniel Vorcaro (Banco Master) e Martha Graeff. Busca, compartilhamento de trechos via link direto e navegação por data.">
-  <meta name="keywords" content="Daniel Vorcaro, Martha Graeff, Banco Master, conversas vazadas, WhatsApp, escândalo, peleleca, colação, momolada, Banco Central, André Esteves, BTG">
+  <meta name="description" content="66 mil mensagens dos celulares apreendidos de Daniel Vorcaro (Banco Master), em 24 conversas — de Martha Graeff a Alexandre de Moraes. Busca, links diretos e navegação por data.">
+  <meta name="keywords" content="Daniel Vorcaro, Banco Master, conversas vazadas, WhatsApp, Alexandre de Moraes, Martha Graeff, Polícia Federal, Operação Compliance Zero, relatório da PF, Barci de Moraes, Paulo Gonet, Galípolo, Banco Central, André Esteves, BTG, escândalo, peleleca, colação, momolada">
   <meta name="author" content="Rafael Bressan">
   <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1">
   <link rel="canonical" href="https://www.masterwhats.com.br/">
 
   <!-- Open Graph -->
   <meta property="og:title" content="MasterWhats — Conversas Vazadas de Daniel Vorcaro">
-  <meta property="og:description" content="Visualizador interativo das 65 mil mensagens vazadas entre Daniel Vorcaro e Martha Graeff. Busca, compartilhamento de trechos e navegação por data no estilo WhatsApp Web.">
+  <meta property="og:description" content="66 mil mensagens dos celulares apreendidos de Daniel Vorcaro, em 24 conversas: de Martha Graeff a Alexandre de Moraes. Busque, navegue por data e compartilhe trechos no estilo WhatsApp Web.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://www.masterwhats.com.br/">
   <meta property="og:image" content="https://www.masterwhats.com.br/assets/og-image.png">
@@ -26,7 +26,7 @@
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="MasterWhats — Conversas Vazadas de Daniel Vorcaro">
-  <meta name="twitter:description" content="65 mil mensagens vazadas entre Daniel Vorcaro e Martha Graeff. Navegue, busque e compartilhe os destaques.">
+  <meta name="twitter:description" content="66 mil mensagens dos celulares de Daniel Vorcaro, em 24 conversas — de Martha Graeff a Alexandre de Moraes. Navegue, busque e compartilhe.">
   <meta name="twitter:image" content="https://www.masterwhats.com.br/assets/og-image.png">
 
   <!-- Favicons & PWA -->
@@ -58,7 +58,8 @@
     "@type": "WebApplication",
     "name": "MasterWhats",
     "url": "https://www.masterwhats.com.br/",
-    "description": "Visualizador interativo das 65.772 mensagens vazadas entre Daniel Vorcaro (Banco Master) e Martha Graeff. Busca, compartilhamento de trechos via link direto, navegação por data e perfis com contexto investigativo.",
+    "description": "Visualizador interativo das 66.387 mensagens extraídas dos celulares apreendidos de Daniel Vorcaro (Banco Master), em 24 conversas: o vazamento das conversas com Martha Graeff e o relatório da Polícia Federal sobre os contatos com o ministro Alexandre de Moraes. Busca, compartilhamento de trechos via link direto, navegação por data e perfis com contexto investigativo.",
+    "dateModified": "2026-09-02",
     "applicationCategory": "UtilitiesApplication",
     "operatingSystem": "Web",
     "inLanguage": "pt-BR",
@@ -75,8 +76,13 @@
       },
       {
         "@type": "Person",
+        "name": "Alexandre de Moraes",
+        "description": "Ministro do Supremo Tribunal Federal; seus contatos com Vorcaro são objeto do relatório IPJ-A 3298613/2026 da Polícia Federal"
+      },
+      {
+        "@type": "Person",
         "name": "Martha Graeff",
-        "description": "Empresária, ex-modelo e influenciadora digital, ex-namorada de Daniel Vorcaro"
+        "description": "Empresária, ex-modelo e influenciadora digital, ex-noiva de Daniel Vorcaro"
       }
     ],
     "offers": {
@@ -102,17 +108,25 @@
     </div>
   </div>
   <div id="app" style="display:none;">
-    <h1 class="sr-only">MasterWhats — Conversas Vazadas de Daniel Vorcaro e Martha Graeff</h1>
+    <h1 class="sr-only">MasterWhats — Conversas Vazadas de Daniel Vorcaro</h1>
   </div>
   <noscript>
     <div style="padding:40px;max-width:700px;margin:0 auto;font-family:Roboto,sans-serif;color:#333;">
       <h1>MasterWhats — Conversas Vazadas de Daniel Vorcaro</h1>
       <h2>Sobre o Projeto</h2>
-      <p>Visualizador interativo das 65.772 mensagens de WhatsApp vazadas entre <a href="https://en.wikipedia.org/wiki/Daniel_Vorcaro">Daniel Vorcaro</a> (Banco Master) e <a href="https://www.infomoney.com.br/politica/martha-graeff-saiba-quem-e-a-ex-noiva-de-vorcaro-nao-localizada-para-depor-em-cpis/">Martha Graeff</a>.</p>
-      <p>Navegue pelas conversas que revelaram conexões com o poder, apelidos carinhosos que viralizaram e o <a href="https://pt.wikipedia.org/wiki/Esc%C3%A2ndalo_do_Banco_Master">maior escândalo bancário da história do Brasil</a>.</p>
+      <p>Visualizador interativo das 66.387 mensagens de WhatsApp extraídas dos celulares apreendidos de <a href="https://en.wikipedia.org/wiki/Daniel_Vorcaro">Daniel Vorcaro</a>, ex-dono do Banco Master, na Operação Compliance Zero. São 24 conversas, de dezembro de 2023 a novembro de 2025, no centro do <a href="https://pt.wikipedia.org/wiki/Esc%C3%A2ndalo_do_Banco_Master">maior escândalo bancário da história do Brasil</a>.</p>
+      <p>O material chegou ao público em dois momentos. Em março de 2026 vazaram as 65.772 mensagens com a então noiva <a href="https://www.infomoney.com.br/politica/martha-graeff-saiba-quem-e-a-ex-noiva-de-vorcaro-nao-localizada-para-depor-em-cpis/">Martha Graeff</a>. Em setembro de 2026 caiu o sigilo do <a href="https://www.poder360.com.br/poder-justica/mendonca-retira-sigilo-de-acao-sobre-vorcaro-e-moraes/">relatório da Polícia Federal</a> que reconstrói, a partir do iPhone de Vorcaro, seus contatos com o ministro Alexandre de Moraes e outras 22 pessoas.</p>
       <h2>Funcionalidades</h2>
-      <p>Busca inteligente com suporte a acentos, compartilhamento de trechos via link direto, navegação por data com calendário, perfis com contexto investigativo e links internos para os trechos citados pela imprensa.</p>
-      <h2>Destaques da Conversa</h2>
+      <p>Busca com suporte a acentos, compartilhamento de trechos via link direto, navegação por data com calendário, perfil de cada contato com contexto investigativo e fontes, e links internos que levam aos trechos citados pela imprensa.</p>
+      <h2>Destaques: o relatório sobre Alexandre de Moraes</h2>
+      <ul>
+        <li>"Acha que segunda ja tenho que estar fora?" — dois dias antes da prisão</li>
+        <li>"É importante reforçar com Andrei e Paulo pra nao deixar ninguem de baixo fazer uma sacanagem" — sobre o diretor-geral da PF e o procurador-geral</li>
+        <li>"Voce sabe que tenho gratidao da minha vida a você" — três dias antes da prisão</li>
+        <li>"Pode pagar sempre, sem nota" — Vorcaro à diretoria, sobre o contrato do escritório Barci de Moraes</li>
+        <li>"Alexandre morre se vc fizer isso" — sobre um convidado vetado no fórum jurídico de Londres</li>
+      </ul>
+      <h2>Destaques: as conversas com Martha Graeff</h2>
       <ul>
         <li>"Fala que eu sou a anarquia do sistema" — Vorcaro sobre si mesmo</li>
         <li>"Peleleca vai estar cabelo branco" — apelido que viralizou nas redes</li>
@@ -123,10 +137,12 @@
       </ul>
       <h2>Fontes</h2>
       <ul>
-        <li><a href="https://www.cnnbrasil.com.br/politica/veja-todas-as-conversas-de-vorcaro-que-vazaram-hoje-para-a-imprensa/">CNN Brasil — Conversas vazadas</a></li>
+        <li><a href="https://www.poder360.com.br/poder-justica/mendonca-retira-sigilo-de-acao-sobre-vorcaro-e-moraes/">Poder360 — Mendonça retira sigilo da ação sobre Vorcaro e Moraes</a></li>
+        <li><a href="https://www.cnnbrasil.com.br/blogs/jussara-soares/politica/como-a-pf-rastreou-as-mensagens-de-vorcaro-a-contato-atribuido-a-moraes/">CNN Brasil — Como a PF rastreou as mensagens de Vorcaro</a></li>
+        <li><a href="https://www.poder360.com.br/poder-justica/pf-encontra-contratos-de-r-208-mi-entre-vorcaro-e-barci-de-moraes/">Poder360 — Contratos de R$ 208 mi com o Barci de Moraes</a></li>
+        <li><a href="https://www.cnnbrasil.com.br/politica/veja-todas-as-conversas-de-vorcaro-que-vazaram-hoje-para-a-imprensa/">CNN Brasil — Conversas vazadas com Martha Graeff</a></li>
         <li><a href="https://ndmais.com.br/justica/vorcaro-momolada-peleleca-conversas-martha-graeff/">ND Mais — Momolada e peleleca</a></li>
         <li><a href="https://www.brasildefato.com.br/2026/03/13/banco-master-a-reconstrucao-completa-de-como-uma-fraude-capturou-a-republica/">Brasil de Fato — Reconstrução da fraude</a></li>
-        <li><a href="https://www.gazetadopovo.com.br/ideias/vazamento-mensagens-vorcaro-processo/">Gazeta do Povo — Vazamento e processo</a></li>
       </ul>
       <p>Projeto feito por <a href="https://linkedin.com/in/rafaelbressan" target="_blank" rel="noopener"><strong>Rafael Bressan</strong></a> com <strong>Claude Code</strong>. <a href="https://github.com/rafaelbressan/masterzap" target="_blank" rel="noopener">Código-fonte no GitHub</a>.</p>
       <p><strong>Este site requer JavaScript para funcionar.</strong></p>

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,24 +1,40 @@
 # MasterWhats
 
-> Visualizador interativo das 65.772 mensagens de WhatsApp vazadas entre Daniel Vorcaro (Banco Master) e Martha Graeff.
+> Visualizador interativo das 66.387 mensagens de WhatsApp extraídas dos celulares apreendidos de Daniel Vorcaro (Banco Master), em 24 conversas — das trocas com Martha Graeff ao relatório da Polícia Federal sobre os contatos com o ministro Alexandre de Moraes.
 
 ## O que é
-MasterWhats é um projeto web que replica a interface do WhatsApp Web para permitir a navegação pelas conversas vazadas do escândalo do Banco Master. O projeto foi criado por Rafael Bressan com Claude Code.
+MasterWhats é um projeto web que replica a interface do WhatsApp Web para permitir a navegação pelas conversas que vieram a público no escândalo do Banco Master. O projeto foi criado por Rafael Bressan com Claude Code. Cada contato tem um perfil que explica quem é a pessoa, o que o material revela e de onde vem a informação, com fontes.
+
+## O material
+O conteúdo vem dos celulares apreendidos de Vorcaro na Operação Compliance Zero e chegou ao público em dois momentos, por caminhos diferentes:
+
+- **Março de 2026 — as conversas com Martha Graeff.** 65.772 mensagens (fevereiro de 2024 a agosto de 2025) trocadas com a então noiva vazaram para a imprensa. Revelaram conexões com autoridades dos Três Poderes, detalhes de operações financeiras e uma linguagem afetiva que viralizou nas redes.
+- **Setembro de 2026 — o relatório da PF sobre Alexandre de Moraes.** Em 1º de setembro caiu o sigilo da IPJ-A nº 3298613/2026, 218 páginas em que a Polícia Federal reconstrói, a partir do iPhone de Vorcaro, seus contatos com o ministro do STF e outras 22 pessoas: diretores do banco, advogados, jornalistas, um diretor do Banco Central. São 615 mensagens em 23 conversas. Vorcaro escrevia no bloco de notas, tirava print e enviava em visualização única; a PF recuperou 52 dessas notas cruzando logs. A PF ressalva que não fez diligências contra magistrados e que o relatório não conclui pela prática de crime.
+
+Se outros vazamentos vierem a público, entram como mais uma conversa.
 
 ## Funcionalidades
-- Navegação por 65.772 mensagens de fevereiro de 2024 a agosto de 2025
-- Busca inteligente com suporte a acentos (pesquisa "voce" encontra "você")
+- 24 conversas, de dezembro de 2023 a novembro de 2025
+- Busca com suporte a acentos (pesquisa "voce" encontra "você"), isolada por conversa
 - Navegação por data com calendário
 - Compartilhamento de trechos via link direto — quem clica cai na mensagem exata
-- Perfis de Daniel Vorcaro e Martha Graeff com contexto investigativo
+- Perfil de cada contato com contexto investigativo e fontes
 - Links internos que levam diretamente aos trechos citados pela imprensa
-- Menu de contexto em cada mensagem (copiar, compartilhar, detalhes)
+- Menu de contexto em cada mensagem (copiar, compartilhar, detalhes, print da tela)
 - Interface responsiva (desktop e mobile) com share nativo no celular
 
 ## Contexto
-Daniel Vorcaro, dono do Banco Master, foi preso pela Polícia Federal em novembro de 2025 após o maior escândalo bancário da história do Brasil. As mensagens trocadas com sua então namorada Martha Graeff foram vazadas em março de 2026, revelando conexões com autoridades dos Três Poderes, detalhes de operações financeiras e uma linguagem afetiva que viralizou nas redes sociais.
+Daniel Vorcaro, dono do Banco Master, foi preso pela Polícia Federal em novembro de 2025 após o maior escândalo bancário da história do Brasil.
 
-## Destaques da conversa
+## Destaques: o relatório sobre Alexandre de Moraes
+- "Acha que segunda ja tenho que estar fora?" — dois dias antes da prisão
+- "É importante reforçar com Andrei e Paulo pra nao deixar ninguem de baixo fazer uma sacanagem" — sobre o diretor-geral da PF e o procurador-geral da República
+- "Voce sabe que tenho gratidao da minha vida a você" — depois de um encontro presencial, três dias antes da prisão
+- "Pode pagar sempre, sem nota" — Vorcaro à diretoria, sobre o contrato de R$ 208 milhões com o escritório Barci de Moraes
+- "Alexandre morre se vc fizer isso" — sobre um convidado vetado no fórum jurídico de Londres bancado pelo banco
+- "O Gonet perguntou se o filho dele pode ir com a gente para Londres?" — o procurador-geral nas tratativas do evento
+
+## Destaques: as conversas com Martha Graeff
 - "Fala que eu sou a anarquia do sistema" — Vorcaro sobre si mesmo
 - "Peleleca vai estar cabelo branco e eu chupando" — apelido que viralizou
 - "Andre disse que era o maior banqueiro do mundo" — sobre André Esteves (BTG)
@@ -30,7 +46,7 @@ Daniel Vorcaro, dono do Banco Master, foi preso pela Polícia Federal em novembr
 ## Fontes
 - Wikipedia: https://en.wikipedia.org/wiki/Daniel_Vorcaro
 - Wikipedia: https://pt.wikipedia.org/wiki/Escândalo_do_Banco_Master
-- CNN Brasil, ND Mais, Gazeta do Povo, InfoMoney, O Tempo, Agência Brasil
+- Poder360 (sigilo derrubado; contratos com o Barci de Moraes), CNN Brasil (como a PF rastreou as mensagens), Metrópoles, Brasil de Fato, ND Mais, Gazeta do Povo, InfoMoney, O Tempo, Agência Brasil
 
 ## Créditos
 Projeto feito por Rafael Bressan (https://linkedin.com/in/rafaelbressan) com Claude Code.

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,10 +1,18 @@
 {
   "name": "MasterWhats",
   "short_name": "MasterWhats",
-  "description": "Visualizador interativo das 65 mil mensagens vazadas entre Daniel Vorcaro e Martha Graeff",
+  "description": "Visualizador interativo das 66 mil mensagens dos celulares apreendidos de Daniel Vorcaro, em 24 conversas",
   "icons": [
-    { "src": "/android-chrome-192x192.png", "sizes": "192x192", "type": "image/png" },
-    { "src": "/android-chrome-512x512.png", "sizes": "512x512", "type": "image/png" }
+    {
+      "src": "/android-chrome-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "/android-chrome-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
   ],
   "theme_color": "#1DAA61",
   "background_color": "#FFFFFF",

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -2,14 +2,20 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://www.masterwhats.com.br/</loc>
-    <lastmod>2026-03-25</lastmod>
+    <lastmod>2026-09-02</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
+    <loc>https://www.masterwhats.com.br/#/chat/alexandre-de-moraes</loc>
+    <lastmod>2026-09-02</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
     <loc>https://www.masterwhats.com.br/#/chat/martha-graeff</loc>
     <lastmod>2026-03-25</lastmod>
-    <changefreq>weekly</changefreq>
+    <changefreq>monthly</changefreq>
     <priority>0.9</priority>
   </url>
 </urlset>


### PR DESCRIPTION
## O que muda

Title, description, keywords, Open Graph, Twitter Card, JSON-LD, `noscript`, `llms.txt`, sitemap, manifest e README ainda descreviam o site como "as 65 mil mensagens entre Vorcaro e Martha Graeff". Desde o relatório da PF são **66.387 mensagens em 24 conversas**, e Alexandre de Moraes é o contato mais procurado.

A moldura é a mesma do "Sobre" do app: o material vem dos celulares apreendidos e chegou ao público em dois momentos, cada um com seu bloco de destaques e fontes. Um vazamento novo entra como mais um bloco.

## O que não muda

- A OG image já era genérica ("Conversas vazadas de Daniel Vorcaro") — fica.
- O `<title>` já não citava a Martha — fica.

## Verificação

- JSON-LD parseia; `about` traz Vorcaro, Moraes e Martha; `dateModified: 2026-09-02`
- manifest e sitemap validam
- 170 unit + 237 E2E verdes no gate de push

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RPgDUnTk2JuejAso8UHMWb