### PR TITLE
Export limpo: Markdown e JSON por conversa, tudo num zip (#7)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,9 @@ dist/
 .vite/
 *.local
 
-# Generated data (rebuild with npm run split-data)
+# Generated data (rebuild with npm run split-data / npm run export)
 public/data/
+public/export/
 
 # Reference files (personal images, design refs)
 ref/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,12 +17,14 @@ npm run dev           # Start dev server
   - 65,772 messages from DV ↔ Martha Graeff (2024-02-10 to 2025-08-13), in `data/messages.json`
   - 615 messages from the Federal Police report IPJ-A 3298613/2026 (23 conversations, including DV ↔ Alexandre de Moraes) — see `data/ipj-3298613/README.md`
 - **Chunking**: `scripts/split_data.py` splits every source conversation into per-date JSON files in `public/data/`
+- **Export**: `scripts/export.mjs` writes `public/export/` — one `.md` and `.json` per conversation, one of each with everything, and a zip. Reads the conversation list from `public/data/conversations.json`, messages from `data/`, profiles from `src/lib/profile-content.js`
 - **Lazy loading**: Only loads day-chunks as user scrolls, with LRU cache
 
 ## Directory Structure
 
 - `src/` — application source (styles, lib, components)
 - `public/data/` — generated chunked data (gitignored, rebuild with `npm run split-data`)
+- `public/export/` — clean export, md/json per conversation + zip (gitignored, rebuild with `npm run export`; runs after split-data, imports the profiles from src/lib)
 - `public/assets/` — static assets (favicon, background, SVGs)
 - `data/` — source data (messages.json, index.json)
 - `data/ipj-3298613/` — transcription of the IPJ-A police report (JSONL, one line per message)
@@ -48,6 +50,7 @@ npm run dev           # Vite dev server
 npm run build         # Production build
 npm run preview       # Preview production build
 npm run split-data    # Regenerate data chunks (all conversations)
+npm run export        # Clean export (md/json per conversation + zip) into public/export/
 npm run test          # Run unit tests (Vitest)
 npm run test:watch    # Unit tests in watch mode
 npm run test:e2e      # E2E tests (Playwright; starts its own dev server)

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ git clone https://github.com/rafaelbressan/masterzap.git
 cd masterzap
 npm install
 npm run split-data    # Gera os arquivos JSON por data em public/data/
+npm run export        # Gera o export limpo (Markdown, JSON, zip) em public/export/
 npm run dev           # Inicia o servidor de desenvolvimento
 ```
 
@@ -69,12 +70,23 @@ npm run test:e2e      # Testes E2E (Playwright)
 ```
 src/                  # Código-fonte (styles, lib, components)
 public/data/          # Dados por data (gitignored, gerado por split-data)
+public/export/        # Export limpo por conversa e completo (gitignored, gerado por export)
 public/assets/        # Assets estáticos (favicon, background, SVGs)
 data/                 # Dados originais (messages.json, index.json)
 scripts/              # Scripts de build (split_data.py)
 tests/unit/           # Testes unitários (Vitest)
 tests/e2e/            # Testes E2E (Playwright)
 ```
+
+## Exportar os dados
+
+Tudo que o site mostra sai limpo, sem precisar do site:
+
+- **Por conversa** — no menu `⋮` de cada chat, "Exportar (.md)" ou "Exportar (.json)".
+- **Tudo** — no menu `⋮` da lista de conversas, "Exportar tudo (.zip)": os 24 pares `.md`/`.json` mais um `README.md`.
+- **Por URL** — `/export/masterwhats-<conversa>.md`, `/export/masterwhats-<conversa>.json`, `/export/masterwhats.md`, `/export/masterwhats.json`, `/export/masterwhats-export.zip`.
+
+O `.md` se explica sozinho: proveniência (fonte, documento e seu sha256, período, fuso), quem é o contato com fontes, e as mensagens dia a dia — as do relatório da PF citam `laudo p. N, fig. M`. O `.json` traz os mesmos metadados e perfil, mais todas as mensagens com os campos originais e `timestamp` com fuso (`-03:00`). Gerado no build por `scripts/export.mjs`, que importa os perfis do próprio app para não descolar.
 
 ## Limitações Conhecidas
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@playwright/test": "^1.50.0",
         "@vitest/coverage-v8": "^3.0.0",
         "jsdom": "^28.1.0",
+        "jszip": "^3.10.1",
         "vite": "^6.2.0",
         "vitest": "^3.0.0"
       }
@@ -1537,6 +1538,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -1922,6 +1930,20 @@
         "node": ">= 14"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -1936,6 +1958,13 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -2064,6 +2093,29 @@
         }
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "dev": true,
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
     "node_modules/loupe": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
@@ -2181,6 +2233,13 @@
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true,
       "license": "BlueOak-1.0.0"
+    },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "dev": true,
+      "license": "(MIT AND Zlib)"
     },
     "node_modules/parse5": {
       "version": "8.0.0",
@@ -2320,6 +2379,13 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -2328,6 +2394,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
     },
     "node_modules/require-from-string": {
@@ -2385,6 +2467,13 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -2410,6 +2499,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -2477,6 +2573,16 @@
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
     },
     "node_modules/string-width": {
       "version": "5.1.2",
@@ -2762,6 +2868,13 @@
       "engines": {
         "node": ">=20.18.1"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/utrie": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -5,19 +5,21 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "python3 scripts/split_data.py && vite build",
+    "build": "python3 scripts/split_data.py && node scripts/export.mjs && vite build",
     "preview": "vite preview",
     "split-data": "python3 scripts/split_data.py",
+    "export": "node scripts/export.mjs",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test --config tests/e2e/playwright.config.js",
-    "verify": "npm run split-data && npm run test && npm run build && npm run test:e2e"
+    "verify": "npm run split-data && npm run export && npm run test && npm run build && npm run test:e2e"
   },
   "devDependencies": {
     "@playwright/test": "^1.50.0",
     "@vitest/coverage-v8": "^3.0.0",
     "jsdom": "^28.1.0",
+    "jszip": "^3.10.1",
     "vite": "^6.2.0",
     "vitest": "^3.0.0"
   },

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -43,6 +43,14 @@ Daniel Vorcaro, dono do Banco Master, foi preso pela Polícia Federal em novembr
 - "Acredita que o presidente bacen ja falou da nossa casa" — sobre a casa de Miami
 - "O pior de ontem foi ter o bolsonaro" — Vorcaro sobre Bolsonaro
 
+## Export limpo
+Tudo que o site mostra, em texto, sem o site:
+- Uma conversa em Markdown: https://www.masterwhats.com.br/export/masterwhats-alexandre-de-moraes.md (troque o id; os ids estão em https://www.masterwhats.com.br/data/conversations.json)
+- A mesma conversa em JSON: https://www.masterwhats.com.br/export/masterwhats-alexandre-de-moraes.json
+- Todas as conversas: https://www.masterwhats.com.br/export/masterwhats.md e https://www.masterwhats.com.br/export/masterwhats.json
+- Zip com tudo: https://www.masterwhats.com.br/export/masterwhats-export.zip
+Cada .md abre com proveniência (fonte, documento e sha256, período, fuso UTC-3), o perfil do contato com fontes, e as mensagens dia a dia; as do relatório da PF citam página e figura do laudo.
+
 ## Fontes
 - Wikipedia: https://en.wikipedia.org/wiki/Daniel_Vorcaro
 - Wikipedia: https://pt.wikipedia.org/wiki/Escândalo_do_Banco_Master

--- a/scripts/export.mjs
+++ b/scripts/export.mjs
@@ -1,0 +1,339 @@
+/**
+ * Write the clean export: one Markdown and one JSON per conversation, one of
+ * each with everything, and a zip of the lot — into public/export/.
+ *
+ * Runs after split_data.py, because the list of conversations and their ids
+ * come from public/data/conversations.json rather than being derived again
+ * here. Messages come from the sources in data/, not from the day chunks, so a
+ * file holds a whole conversation at once.
+ *
+ * Node rather than Python because the contact profiles live in
+ * src/lib/profile-content.js. Importing them keeps the export and the site
+ * saying the same thing — a profile edited in one place is edited in both.
+ */
+
+import { readFileSync, writeFileSync, mkdirSync, existsSync, readdirSync } from 'node:fs';
+import { createHash } from 'node:crypto';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import JSZip from 'jszip';
+
+import { getContactProfile, VORCARO_PROFILE, SOURCES } from '../src/lib/profile-content.js';
+import { SETTINGS_CONTENT } from '../src/lib/settings-content.js';
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+const DATA_DIR = join(ROOT, 'data');
+const PUBLIC_DATA = join(ROOT, 'public/data');
+const OUT = join(ROOT, 'public/export');
+
+const SITE = 'https://www.masterwhats.com.br';
+const REPO = 'https://github.com/rafaelbressan/masterzap';
+const FORMAT_VERSION = 1;
+
+// The phones were seized in Brazil and every timestamp in the sources is local
+// wall-clock time. Brazil has had no daylight saving since 2019, so from the
+// first message (December 2023) on the offset is a constant.
+const TIMEZONE = 'America/Sao_Paulo';
+const UTC_OFFSET = '-03:00';
+
+const REPORT_PDF = 'data/source/IPJ-A-3298613-2026.pdf';
+
+const generatedAt = new Date().toISOString();
+
+// ── sources ────────────────────────────────────────────────────────────────
+
+const entries = JSON.parse(readFileSync(join(PUBLIC_DATA, 'conversations.json'), 'utf-8')).conversations;
+
+/** The Martha export is the one source without a `source` field. */
+function loadMessages(entry) {
+  const fromReport = join(DATA_DIR, 'conversations', `${entry.id}.json`);
+  if (existsSync(fromReport)) {
+    return JSON.parse(readFileSync(fromReport, 'utf-8')).messages;
+  }
+  return JSON.parse(readFileSync(join(DATA_DIR, 'messages.json'), 'utf-8')).messages;
+}
+
+function sha256(path) {
+  if (!existsSync(path)) return null;
+  return createHash('sha256').update(readFileSync(path)).digest('hex');
+}
+
+const reportSha = sha256(join(ROOT, REPORT_PDF));
+
+/** Where a conversation's text came from, in the terms the reader will need. */
+function sourceOf(entry) {
+  if (entry.source?.startsWith('IPJ-A')) {
+    return {
+      kind: 'police-report',
+      label: entry.source,
+      document: REPORT_PDF,
+      document_sha256: reportSha,
+      made_public: '2026-09-01',
+      how: 'Transcrição manual das imagens do laudo; cada mensagem cita a página e a figura de origem.',
+    };
+  }
+  return {
+    kind: 'leak',
+    label: 'Vazamento das conversas com Martha Graeff, março de 2026',
+    document: null,
+    document_sha256: null,
+    made_public: '2026-03',
+    how: 'Export de WhatsApp extraído do celular apreendido, vazado para a imprensa.',
+  };
+}
+
+// ── text helpers ───────────────────────────────────────────────────────────
+
+const urlsIn = (text) => [...text.matchAll(/\{[^}]+\}\[(https?:\/\/[^\]]+)\]/g)].map(m => m[1]);
+
+/** The site's {text}[url] links as Markdown; action: links become plain text. */
+const linksToMarkdown = (text) => text.replace(/\{([^}]+)\}\[([^\]]+)\]/g,
+  (_, t, url) => (url.startsWith('action:') ? t : `[${t}](${url})`));
+
+const dateFmt = new Intl.DateTimeFormat('pt-BR', { day: 'numeric', month: 'long', year: 'numeric' });
+const longDate = (iso) => dateFmt.format(new Date(`${iso}T12:00:00`));
+
+const contactOf = (entry) => entry.participants.find(p => p !== 'DV') || entry.participants[0];
+
+const phonePretty = (p) => (p && /^55\d{10,11}$/.test(p)
+  ? `+55 ${p.slice(2, 4)} ${p.slice(4, -4)}-${p.slice(-4)}`
+  : p || null);
+
+const MEDIA = {
+  image: 'Foto', video: 'Vídeo', audio: 'Áudio', sticker: 'Sticker',
+  document: 'Documento', call: 'Chamada', deleted: 'Mensagem apagada', system: 'Sistema',
+};
+
+/** One message as it reads without the app. */
+function messageBody(msg) {
+  const text = (msg.content || '').trim();
+  switch (msg.type) {
+    case 'text':
+      return text;
+    case 'document':
+      return `_[Documento${msg.attachment ? `: ${msg.attachment}` : ''}]_${text ? `\n${text}` : ''}`;
+    case 'image':
+      // A view-once image whose content the forensics could not recover keeps
+      // the placeholder text the source gave it.
+      if (text.startsWith('[')) return `_${text}_`;
+      return `_[Foto]_${text ? `\n${text}` : ''}`;
+    case 'video': case 'audio': case 'sticker':
+      return `_[${MEDIA[msg.type]}]_${text ? `\n${text}` : ''}`;
+    case 'call':
+      return `_[${text || 'Chamada'}]_`;
+    case 'deleted':
+      return `_[${text || 'Mensagem apagada'}]_`;
+    case 'system':
+      return `_(${text})_`;
+    default:
+      return text;
+  }
+}
+
+/** A leading #, > or - would turn a line of chat into markup. */
+const escapeLine = (line) => line.replace(/^([#>\-+*]|\d+\.)(?=\s|$)/, '\\$1');
+
+// ── profile ────────────────────────────────────────────────────────────────
+
+function profileMarkdown(title, profile) {
+  if (!profile) return { text: '', urls: [] };
+  const urls = [];
+  const out = [`## ${title}`, ''];
+  for (const section of profile.sections || []) {
+    const who = title.replace(/^Quem é /, '');
+    if (section.title && section.title !== who && section.title !== `Sobre ${who}`) {
+      out.push(`### ${section.title}`, '');
+    }
+    for (const p of section.paragraphs || []) {
+      urls.push(...urlsIn(p.text));
+      out.push(linksToMarkdown(p.text), '');
+    }
+  }
+  return { text: out.join('\n'), urls };
+}
+
+function profileJson(profile) {
+  if (!profile) return null;
+  const urls = [];
+  const sections = (profile.sections || []).map(s => ({
+    title: s.title || null,
+    paragraphs: (s.paragraphs || []).map(p => {
+      urls.push(...urlsIn(p.text));
+      return linksToMarkdown(p.text);
+    }),
+  }));
+  return { about: profile.about || null, sections, sources: [...new Set(urls)] };
+}
+
+// ── one conversation ───────────────────────────────────────────────────────
+
+function conversationMarkdown(entry, messages, { standalone = true } = {}) {
+  const contact = contactOf(entry);
+  const source = sourceOf(entry);
+  const profile = getContactProfile(entry.id);
+  const heading = standalone ? '#' : '##';
+  const sub = standalone ? '##' : '###';
+  const out = [];
+
+  out.push(`${heading} Daniel Vorcaro ↔ ${contact}`, '');
+  if (standalone) {
+    out.push(`> Exportado de [MasterWhats](${SITE}/#/chat/${entry.id}) em ${generatedAt.slice(0, 10)}. Código e dados: ${REPO}.`, '');
+  }
+
+  out.push(`${sub} Proveniência`, '', '| | |', '|---|---|');
+  out.push(`| Fonte | ${source.label} |`);
+  if (source.document) out.push(`| Documento | \`${source.document}\` (sha256 \`${source.document_sha256 || 'n/d'}\`) |`);
+  out.push(`| Como chegou ao público | ${source.how} |`);
+  out.push(`| Período | ${entry.date_range.start} a ${entry.date_range.end} |`);
+  out.push(`| Mensagens | ${entry.total_messages} |`);
+  if (entry.saved_as) out.push(`| Contato salvo como | ${entry.saved_as} |`);
+  if (entry.phone) out.push(`| Telefone | ${phonePretty(entry.phone)} |`);
+  out.push(`| Fuso dos horários | ${TIMEZONE} (UTC${UTC_OFFSET}) |`);
+  if (entry.note) out.push(`| Observação | ${entry.note} |`);
+  out.push('');
+
+  // The saved contact name is how the phone knew the person ("Alexandre de
+  // Moraes BRASILIA"); the profile knows who they are.
+  const who = profile?.name || profile?.sections?.[0]?.title?.replace(/^Sobre /, '') || contact;
+  const { text: profileText, urls } = profileMarkdown(`Quem é ${who}`, profile);
+  if (profileText) out.push(profileText.replace(/^## /, `${sub} `).replace(/\n### /g, `\n${standalone ? '###' : '####'} `));
+
+  out.push(`${sub} Conversa`, '');
+  let day = null;
+  for (const msg of messages) {
+    if (msg.date !== day) {
+      day = msg.date;
+      out.push(`${standalone ? '###' : '####'} ${longDate(day)}`, '');
+    }
+    const tags = [msg.time.slice(0, 5)];
+    if (msg.is_edited) tags.push('editada');
+    if (msg.view_once) tags.push('visualização única');
+    if (msg.source_page) tags.push(`laudo p. ${msg.source_page}${msg.source_figure ? `, fig. ${msg.source_figure}` : ''}`);
+    out.push(`**${msg.sender}** · ${tags.join(' · ')}`);
+    const body = messageBody(msg);
+    if (body) out.push(...body.split('\n').map(escapeLine));
+    out.push('');
+  }
+
+  const sources = [...new Set(urls)];
+  if (sources.length) {
+    out.push(`${sub} Fontes`, '', ...sources.map(u => `- ${u}`), '');
+  }
+  return out.join('\n');
+}
+
+function conversationJson(entry, messages) {
+  const source = sourceOf(entry);
+  return {
+    export: {
+      generated_at: generatedAt, format_version: FORMAT_VERSION,
+      site: SITE, url: `${SITE}/#/chat/${entry.id}`, repository: REPO,
+      timezone: TIMEZONE, utc_offset: UTC_OFFSET,
+    },
+    conversation: {
+      id: entry.id,
+      participants: entry.participants,
+      contact: contactOf(entry),
+      saved_as: entry.saved_as || null,
+      phone: entry.phone || null,
+      date_range: entry.date_range,
+      total_messages: entry.total_messages,
+      media_counts: entry.media_counts,
+      source: source.label,
+      source_detail: source,
+      note: entry.note || null,
+    },
+    profile: profileJson(getContactProfile(entry.id)),
+    messages: messages.map(m => ({ ...m, timestamp: `${m.timestamp}${UTC_OFFSET}` })),
+  };
+}
+
+// ── everything ─────────────────────────────────────────────────────────────
+
+function aboutMarkdown() {
+  const about = SETTINGS_CONTENT.sections.find(s => s.title === 'Sobre o Projeto');
+  const out = ['## Sobre o projeto', ''];
+  for (const p of about?.paragraphs || []) out.push(linksToMarkdown(p.text), '');
+  return out.join('\n');
+}
+
+function readme(conversations) {
+  const total = conversations.reduce((n, c) => n + c.total_messages, 0);
+  return [
+    '# MasterWhats — export completo', '',
+    `Gerado em ${generatedAt.slice(0, 10)} a partir de ${SITE}. ${conversations.length} conversas, ${total} mensagens.`, '',
+    '## O que tem aqui', '',
+    '| Arquivo | Conteúdo |', '|---|---|',
+    '| `masterwhats-<conversa>.md` | Uma conversa legível: proveniência, quem é o contato (com fontes) e as mensagens, dia a dia |',
+    '| `masterwhats-<conversa>.json` | A mesma conversa como dados: metadados, perfil e todas as mensagens com os campos originais |',
+    '| `masterwhats.md` / `masterwhats.json` | Tudo num arquivo só |', '',
+    '## Como ler', '',
+    `- Horários em ${TIMEZONE} (UTC${UTC_OFFSET}); no JSON, cada \`timestamp\` já carrega o fuso.`,
+    '- Mensagens do relatório da PF trazem `laudo p. N, fig. M` — página e figura do PDF de origem, para conferência.',
+    '- `_[Foto]_`, `_[Vídeo]_`, `_[Áudio]_`, `_[Documento]_`: a mídia não faz parte do material público; só o tipo é conhecido.',
+    '- `[imagem de visualização única — conteúdo não recuperado]`: enviada em visualização única e não recuperada pela perícia.', '',
+    aboutMarkdown(),
+    '## Fontes gerais', '', ...SOURCES.map(s => `- [${s.label}](${s.url})`), '',
+    `## Aviso`, '',
+    'As informações aqui compiladas são de domínio público, extraídas de reportagens jornalísticas e de documentos cujo sigilo foi levantado judicialmente. Este projeto não tem vinculação com nenhuma das partes envolvidas.', '',
+  ].join('\n');
+}
+
+function allMarkdown(built) {
+  const total = built.reduce((n, b) => n + b.entry.total_messages, 0);
+  const out = [
+    '# MasterWhats — todas as conversas', '',
+    `> Exportado de [MasterWhats](${SITE}) em ${generatedAt.slice(0, 10)}. ${built.length} conversas, ${total} mensagens. Código e dados: ${REPO}.`, '',
+    aboutMarkdown(),
+    profileMarkdown('Quem é Daniel Vorcaro', VORCARO_PROFILE).text,
+    '## Conversas', '',
+    ...built.map(b => `- [${contactOf(b.entry)}](#${b.entry.id}) — ${b.entry.total_messages} mensagens, ${b.entry.date_range.start} a ${b.entry.date_range.end}`),
+    '', '---', '',
+  ];
+  for (const b of built) {
+    out.push(`<a id="${b.entry.id}"></a>`, '');
+    out.push(conversationMarkdown(b.entry, b.messages, { standalone: false }), '---', '');
+  }
+  return out.join('\n');
+}
+
+// ── run ────────────────────────────────────────────────────────────────────
+
+mkdirSync(OUT, { recursive: true });
+for (const stale of readdirSync(OUT)) {
+  if (/^masterwhats/.test(stale)) writeFileSync(join(OUT, stale), '');
+}
+
+const zip = new JSZip();
+const built = [];
+
+for (const entry of entries) {
+  const messages = loadMessages(entry);
+  if (messages.length !== entry.total_messages) {
+    console.error(`${entry.id}: ${messages.length} messages in source, ${entry.total_messages} in conversations.json`);
+    process.exit(1);
+  }
+  const mdText = conversationMarkdown(entry, messages);
+  const jsonText = JSON.stringify(conversationJson(entry, messages), null, 1);
+  writeFileSync(join(OUT, `masterwhats-${entry.id}.md`), mdText);
+  writeFileSync(join(OUT, `masterwhats-${entry.id}.json`), jsonText);
+  zip.file(`masterwhats-${entry.id}.md`, mdText);
+  zip.file(`masterwhats-${entry.id}.json`, jsonText);
+  built.push({ entry, messages });
+  console.log(`${entry.id}: ${messages.length} messages, ${(mdText.length / 1024).toFixed(0)} kB md`);
+}
+
+const allMd = allMarkdown(built);
+const allJson = JSON.stringify({
+  export: { generated_at: generatedAt, format_version: FORMAT_VERSION, site: SITE, repository: REPO, timezone: TIMEZONE, utc_offset: UTC_OFFSET },
+  conversations: built.map(b => conversationJson(b.entry, b.messages)),
+});
+writeFileSync(join(OUT, 'masterwhats.md'), allMd);
+writeFileSync(join(OUT, 'masterwhats.json'), allJson);
+zip.file('README.md', readme(entries));
+
+const zipBuf = await zip.generateAsync({ type: 'nodebuffer', compression: 'DEFLATE', compressionOptions: { level: 9 } });
+writeFileSync(join(OUT, 'masterwhats-export.zip'), zipBuf);
+
+console.log(`\nDone! ${built.length} conversations → ${OUT}`);
+console.log(`masterwhats.md ${(allMd.length / 1048576).toFixed(1)} MB, masterwhats.json ${(allJson.length / 1048576).toFixed(1)} MB, zip ${(zipBuf.length / 1048576).toFixed(1)} MB`);

--- a/src/components/ChatView.js
+++ b/src/components/ChatView.js
@@ -10,7 +10,7 @@
  */
 import { escapeHtml, formatTime, formatDateLong, linkify } from '../lib/utils.js';
 import { ScrollLoader } from '../lib/scroll-loader.js';
-import { ICON_INFO, ICON_SEARCH, ICON_CHECKEMPTY, ICON_BELL, ICON_TIMER, ICON_CLOSE_CIRCULAR, ICON_MASTERZAP_LOGO, ICON_MEETBALL, ICON_CHEVRON_DW, ICON_SCREENSHOT } from '../lib/icons.js';
+import { ICON_INFO, ICON_SEARCH, ICON_CHECKEMPTY, ICON_BELL, ICON_TIMER, ICON_DOWNLOAD, ICON_CLOSE_CIRCULAR, ICON_MASTERZAP_LOGO, ICON_MEETBALL, ICON_CHEVRON_DW, ICON_SCREENSHOT } from '../lib/icons.js';
 
 import { defaultAvatarSvg } from '../lib/avatar.js';
 
@@ -289,7 +289,7 @@ function renderMessage(msg) {
  */
 // Use the design system meetball icon for 3-dot menu
 
-export function renderChatView(container, { conversation, dateIndex, loadMessages, onBack, onContactClick, onSearch, onCloseChat, onAbout, onScreenshot, onMenuOpen }) {
+export function renderChatView(container, { conversation, dateIndex, loadMessages, onBack, onContactClick, onSearch, onCloseChat, onAbout, onScreenshot, onExport, onMenuOpen }) {
   // Clear container
   while (container.firstChild) container.removeChild(container.firstChild);
 
@@ -379,6 +379,8 @@ export function renderChatView(container, { conversation, dateIndex, loadMessage
       { label: 'Modo silencioso', icon: ICON_BELL, action: null, enabled: false },
       { label: 'Mensagens temporárias', icon: ICON_TIMER, action: null, enabled: false },
       { label: 'Compartilhar print', icon: ICON_SCREENSHOT, action: onScreenshot, enabled: !!onScreenshot },
+      { label: 'Exportar (.md)', icon: ICON_DOWNLOAD, action: () => onExport('md'), enabled: !!onExport },
+      { label: 'Exportar (.json)', icon: ICON_DOWNLOAD, action: () => onExport('json'), enabled: !!onExport },
       { label: 'Fechar conversa', icon: ICON_CLOSE_CIRCULAR, action: onCloseChat || onBack, enabled: !!(onCloseChat || onBack) },
       { label: 'Sobre o MasterWhats', icon: ICON_MASTERZAP_LOGO, action: onAbout, enabled: !!onAbout },
     ];

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -22,7 +22,7 @@ export const FAVORITE_CONVERSATIONS = new Set(['alexandre-de-moraes', 'martha-gr
  * @param {function} options.onSelect - called with conversation id
  * @param {Set<string>} [options.readConversations] - ids already opened
  */
-export function renderSidebar(container, { conversations, onSelect, onProfile, onAbout, readConversations = new Set() }) {
+export function renderSidebar(container, { conversations, onSelect, onProfile, onAbout, onExportAll, readConversations = new Set() }) {
   const el = document.createElement('aside');
   el.className = 'sidebar';
   el.setAttribute('role', 'navigation');
@@ -243,6 +243,7 @@ export function renderSidebar(container, { conversations, onSelect, onProfile, o
 
     const items = [
       { label: 'Perfil', action: onProfile, enabled: !!onProfile },
+      { label: 'Exportar tudo (.zip)', action: onExportAll, enabled: !!onExportAll },
       { label: 'Sobre o MasterWhats', action: onAbout, enabled: !!onAbout },
     ];
 

--- a/src/lib/export.js
+++ b/src/lib/export.js
@@ -1,0 +1,29 @@
+/**
+ * Where the clean export lives and how to hand it to the browser.
+ *
+ * The files are written at build time by scripts/export.mjs, so "exporting"
+ * here is only a download of something that already exists. Filenames match
+ * what the script writes; if one changes, the other has to.
+ */
+
+export const EXPORT_BASE = '/export';
+export const EXPORT_FORMATS = ['md', 'json'];
+
+/** URL of one conversation's export in the given format. */
+export function exportUrl(conversationId, format) {
+  if (!EXPORT_FORMATS.includes(format)) throw new Error(`formato desconhecido: ${format}`);
+  return `${EXPORT_BASE}/masterwhats-${conversationId}.${format}`;
+}
+
+/** URL of the zip with every conversation in both formats. */
+export const EXPORT_ALL_URL = `${EXPORT_BASE}/masterwhats-export.zip`;
+
+/** Start a download of a same-origin file, keeping its name. */
+export function downloadFile(url) {
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = url.slice(url.lastIndexOf('/') + 1);
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+}

--- a/src/lib/icons.js
+++ b/src/lib/icons.js
@@ -26,3 +26,5 @@ export const ICON_MEETBALL = `<svg viewBox="0 0 24 24" width="20" height="20" fi
 export const ICON_CHEVRON_DW = `<svg viewBox="0 0 12 12" width="12" height="12" fill="currentColor"><path fill-rule="evenodd" clip-rule="evenodd" d="M10.4242 3.57576C10.6586 3.81007 10.6586 4.18997 10.4242 4.42429L6.42424 8.42429C6.18992 8.6586 5.81003 8.6586 5.57571 8.42429L1.57571 4.42429C1.3414 4.18997 1.3414 3.81007 1.57571 3.57576C1.81003 3.34145 2.18993 3.34145 2.42424 3.57576L5.99998 7.1515L9.57571 3.57576C9.81003 3.34145 10.1899 3.34145 10.4242 3.57576Z"/></svg>`;
 
 export const ICON_MASTERZAP_LOGO = `<img src="/assets/masterzap-logo.png" width="20" height="20" alt="" style="vertical-align:middle;" />`;
+
+export const ICON_DOWNLOAD = `<svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4v11"/><path d="m7.5 10.5 4.5 4.5 4.5-4.5"/><path d="M4 17.5v1a1.5 1.5 0 0 0 1.5 1.5h13a1.5 1.5 0 0 0 1.5-1.5v-1"/></svg>`;

--- a/src/main.js
+++ b/src/main.js
@@ -21,6 +21,7 @@ import {
   shareImageFile, canShareFiles,
 } from './lib/screenshot.js';
 import { showImagePreview } from './components/ImagePreview.js';
+import { exportUrl, EXPORT_ALL_URL, downloadFile } from './lib/export.js';
 
 // ── Active state (only one thing at a time) ──────
 let activeLoader = null;
@@ -323,6 +324,7 @@ async function init() {
       onAbout: openSettings,
       onSearch: toggleSearch,
       onScreenshot: shareScreenshot,
+      onExport: (format) => downloadFile(exportUrl(conversation.id, format)),
       onMenuOpen: () => prepareScreenshot(mainArea, contactName),
       onContactClick: () => {
         // Only one right drawer at a time
@@ -465,6 +467,7 @@ async function init() {
     readConversations,
     onProfile: openProfile,
     onAbout: openSettings,
+    onExportAll: () => downloadFile(EXPORT_ALL_URL),
     onSelect: (id) => {
       // Close profile/settings if open before navigating
       closeProfile();

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -127,9 +127,9 @@
   flex: 1;
 }
 
-/* Hidden on desktop, shown on mobile via media query */
+/* The list's own menu, as on WhatsApp Web. Home of "Exportar tudo". */
 .sidebar-menu-btn {
-  display: none;
+  display: flex;
   background: none;
   border: none;
   padding: 8px;

--- a/src/styles/mobile.css
+++ b/src/styles/mobile.css
@@ -103,11 +103,6 @@
     width: 100%;
   }
 
-  /* Show sidebar menu button on mobile */
-  .sidebar-menu-btn {
-    display: flex;
-  }
-
   /* Show bottom nav on mobile */
   .sidebar-bottom-nav {
     display: flex;

--- a/tests/e2e/export.test.js
+++ b/tests/e2e/export.test.js
@@ -1,0 +1,64 @@
+import { test, expect } from '@playwright/test';
+
+// The export is a file the build already wrote; what the app has to get right
+// is offering it where the reader is, and handing over the right file.
+
+const openChatMenu = async (page) => {
+  await page.goto('/#/chat/ciro-soares');
+  await expect(page.locator('.chat-msg-bubble').first()).toBeVisible();
+  await page.locator('.chat-header button[aria-label="Menu"]').click();
+};
+
+test.describe('Exporting one conversation', () => {
+  test('the menu offers both formats', async ({ page }) => {
+    await openChatMenu(page);
+    await expect(page.locator('.chat-dropdown-item', { hasText: 'Exportar (.md)' })).toBeVisible();
+    await expect(page.locator('.chat-dropdown-item', { hasText: 'Exportar (.json)' })).toBeVisible();
+  });
+
+  // Two more items must not push the menu off a phone screen.
+  test('the menu still fits on screen', async ({ page }) => {
+    await openChatMenu(page);
+    const menu = await page.locator('.chat-dropdown-menu').boundingBox();
+    const { width, height } = page.viewportSize();
+    expect(menu.y).toBeGreaterThanOrEqual(0);
+    expect(menu.y + menu.height).toBeLessThanOrEqual(height);
+    expect(menu.x + menu.width).toBeLessThanOrEqual(width);
+  });
+
+  for (const format of ['md', 'json']) {
+    test(`downloads the conversation as .${format}, under its own name`, async ({ page }) => {
+      await openChatMenu(page);
+      const [download] = await Promise.all([
+        page.waitForEvent('download'),
+        page.locator('.chat-dropdown-item', { hasText: `Exportar (.${format})` }).click(),
+      ]);
+      expect(download.suggestedFilename()).toBe(`masterwhats-ciro-soares.${format}`);
+      const path = await download.path();
+      expect(path).toBeTruthy();
+    });
+  }
+
+  test('the menu closes once the download starts', async ({ page }) => {
+    await openChatMenu(page);
+    await Promise.all([
+      page.waitForEvent('download'),
+      page.locator('.chat-dropdown-item', { hasText: 'Exportar (.md)' }).click(),
+    ]);
+    await expect(page.locator('.chat-dropdown-menu')).toBeHidden();
+  });
+});
+
+test.describe('Exporting everything', () => {
+  test('the home menu offers the zip and downloads it', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.locator('.conversation-item').first()).toBeVisible();
+    await page.locator('.sidebar-menu-btn').click();
+
+    const item = page.locator('.sidebar-dropdown-item', { hasText: 'Exportar tudo (.zip)' });
+    await expect(item).toBeVisible();
+
+    const [download] = await Promise.all([page.waitForEvent('download'), item.click()]);
+    expect(download.suggestedFilename()).toBe('masterwhats-export.zip');
+  });
+});

--- a/tests/e2e/share.test.js
+++ b/tests/e2e/share.test.js
@@ -72,6 +72,8 @@ test.describe('Chat Interactions', () => {
       'Modo silencioso',
       'Mensagens temporárias',
       'Compartilhar print',
+      'Exportar (.md)',
+      'Exportar (.json)',
       'Fechar conversa',
       'Sobre o MasterWhats',
     ]);

--- a/tests/unit/export-data.test.js
+++ b/tests/unit/export-data.test.js
@@ -1,0 +1,138 @@
+// @vitest-environment node
+//
+// Guards on the export the build writes to public/export. The files are what a
+// reader, a script or a model gets without the app in between, so what matters
+// is that each one stands on its own: says where it came from, keeps every
+// message, and leaves nothing that only makes sense inside the site.
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync, statSync } from 'fs';
+import { join } from 'path';
+import JSZip from 'jszip';
+
+const ROOT = join(import.meta.dirname, '../..');
+const DATA_DIR = join(ROOT, 'public/data');
+const EXPORT_DIR = join(ROOT, 'public/export');
+
+const conversations = JSON.parse(
+  readFileSync(join(DATA_DIR, 'conversations.json'), 'utf-8')
+).conversations;
+
+const md = (id) => readFileSync(join(EXPORT_DIR, `masterwhats-${id}.md`), 'utf-8');
+const json = (id) => JSON.parse(readFileSync(join(EXPORT_DIR, `masterwhats-${id}.json`), 'utf-8'));
+
+describe('one pair of files per conversation', () => {
+  it('writes a .md and a .json for every conversation the site lists', () => {
+    for (const conv of conversations) {
+      expect(existsSync(join(EXPORT_DIR, `masterwhats-${conv.id}.md`)), conv.id).toBe(true);
+      expect(existsSync(join(EXPORT_DIR, `masterwhats-${conv.id}.json`)), conv.id).toBe(true);
+    }
+  });
+});
+
+describe('the JSON', () => {
+  it('keeps every message', () => {
+    for (const conv of conversations) {
+      expect(json(conv.id).messages.length, conv.id).toBe(conv.total_messages);
+    }
+  });
+
+  it('stamps every timestamp with its UTC offset', () => {
+    for (const conv of conversations) {
+      for (const msg of json(conv.id).messages) {
+        expect(msg.timestamp, `${conv.id} #${msg.id}`).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}-03:00$/);
+      }
+    }
+  });
+
+  it('says where it came from', () => {
+    for (const conv of conversations) {
+      const { export: meta, conversation } = json(conv.id);
+      expect(meta.site).toBe('https://www.masterwhats.com.br');
+      expect(meta.timezone).toBe('America/Sao_Paulo');
+      expect(conversation.id).toBe(conv.id);
+      expect(conversation.source, conv.id).toBeTruthy();
+    }
+  });
+
+  it('keeps the page and figure of the police report on every message that has one', () => {
+    const fromReport = conversations.filter(c => c.source?.startsWith('IPJ-A'));
+    expect(fromReport.length).toBeGreaterThan(0);
+    for (const conv of fromReport) {
+      for (const msg of json(conv.id).messages) {
+        expect(msg.source_page, `${conv.id} #${msg.id}`).toBeGreaterThan(0);
+      }
+    }
+  });
+});
+
+describe('the Markdown', () => {
+  it('opens with a provenance block', () => {
+    for (const conv of conversations) {
+      const text = md(conv.id);
+      expect(text, conv.id).toMatch(/^# /);
+      expect(text, conv.id).toContain('## Proveniência');
+      expect(text, conv.id).toContain('| Fonte |');
+      expect(text, conv.id).toContain('| Fuso dos horários | America/Sao_Paulo');
+    }
+  });
+
+  it('carries the contact profile with its sources, as links', () => {
+    const text = md('alexandre-de-moraes');
+    expect(text).toContain('## Quem é Alexandre de Moraes');
+    expect(text).toMatch(/\[[^\]]+\]\(https?:\/\/[^)]+\)/);
+    expect(text).toContain('## Fontes');
+  });
+
+  it('leaves no site-only markup behind', () => {
+    for (const conv of conversations) {
+      const text = md(conv.id);
+      expect(text, `${conv.id} has raw {text}[url]`).not.toMatch(/\{[^}]+\}\[[^\]]+\]/);
+      expect(text, `${conv.id} has action: link`).not.toContain('[action:');
+      expect(text, `${conv.id} has action: link`).not.toContain('profile-action-link');
+      expect(text, `${conv.id} has html`).not.toMatch(/<(a|span|div) /);
+    }
+  });
+
+  it('cites the page of the report on every message from it', () => {
+    const text = md('alexandre-de-moraes');
+    const headers = text.split('\n').filter(l => /^\*\*.+\*\* · \d{2}:\d{2}/.test(l));
+    expect(headers.length).toBe(62);
+    for (const line of headers) expect(line).toMatch(/laudo p\. \d+/);
+  });
+
+  it('keeps every message', () => {
+    for (const conv of conversations) {
+      const headers = md(conv.id).split('\n').filter(l => /^\*\*.+\*\* · \d{2}:\d{2}/.test(l));
+      expect(headers.length, conv.id).toBe(conv.total_messages);
+    }
+  });
+});
+
+describe('everything at once', () => {
+  it('writes one Markdown with every conversation in it', () => {
+    const text = readFileSync(join(EXPORT_DIR, 'masterwhats.md'), 'utf-8');
+    for (const conv of conversations) {
+      expect(text, conv.id).toContain(`(#${conv.id})`);
+    }
+    expect(text).toContain('## Sobre o projeto');
+  });
+
+  it('writes one JSON with every conversation in it', () => {
+    const all = JSON.parse(readFileSync(join(EXPORT_DIR, 'masterwhats.json'), 'utf-8'));
+    expect(all.conversations.map(c => c.conversation.id).sort())
+      .toEqual(conversations.map(c => c.id).sort());
+  });
+
+  it('zips the pairs, with a README on top', async () => {
+    const path = join(EXPORT_DIR, 'masterwhats-export.zip');
+    expect(statSync(path).size).toBeGreaterThan(100_000);
+    const zip = await JSZip.loadAsync(readFileSync(path));
+    const names = Object.keys(zip.files);
+    expect(names).toContain('README.md');
+    for (const conv of conversations) {
+      expect(names, conv.id).toContain(`masterwhats-${conv.id}.md`);
+      expect(names, conv.id).toContain(`masterwhats-${conv.id}.json`);
+    }
+  });
+});

--- a/tests/unit/export.test.js
+++ b/tests/unit/export.test.js
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { exportUrl, EXPORT_ALL_URL, downloadFile } from '../../src/lib/export.js';
+
+describe('exportUrl', () => {
+  it('points at the file the build writes', () => {
+    expect(exportUrl('alexandre-de-moraes', 'md')).toBe('/export/masterwhats-alexandre-de-moraes.md');
+    expect(exportUrl('martha-graeff', 'json')).toBe('/export/masterwhats-martha-graeff.json');
+  });
+
+  it('refuses a format the build does not produce', () => {
+    expect(() => exportUrl('x', 'csv')).toThrow();
+  });
+
+  it('has one zip for everything', () => {
+    expect(EXPORT_ALL_URL).toBe('/export/masterwhats-export.zip');
+  });
+});
+
+describe('downloadFile', () => {
+  it('downloads under the file\'s own name', () => {
+    const clicked = [];
+    const original = HTMLAnchorElement.prototype.click;
+    HTMLAnchorElement.prototype.click = function () { clicked.push({ href: this.getAttribute('href'), download: this.download }); };
+    try {
+      downloadFile('/export/masterwhats-ciro-soares.md');
+    } finally {
+      HTMLAnchorElement.prototype.click = original;
+    }
+    expect(clicked).toEqual([{ href: '/export/masterwhats-ciro-soares.md', download: 'masterwhats-ciro-soares.md' }]);
+    expect(document.querySelector('a[download]')).toBeNull();
+  });
+});

--- a/vercel.json
+++ b/vercel.json
@@ -1,50 +1,104 @@
 {
   "rewrites": [
-    { "source": "/robots.txt", "destination": "/robots.txt" },
-    { "source": "/sitemap.xml", "destination": "/sitemap.xml" },
-    { "source": "/llms.txt", "destination": "/llms.txt" },
-    { "source": "/site.webmanifest", "destination": "/site.webmanifest" },
-    { "source": "/(.*)", "destination": "/index.html" }
+    {
+      "source": "/robots.txt",
+      "destination": "/robots.txt"
+    },
+    {
+      "source": "/sitemap.xml",
+      "destination": "/sitemap.xml"
+    },
+    {
+      "source": "/llms.txt",
+      "destination": "/llms.txt"
+    },
+    {
+      "source": "/site.webmanifest",
+      "destination": "/site.webmanifest"
+    },
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
   ],
   "headers": [
     {
       "source": "/(.*)",
       "headers": [
-        { "key": "X-Content-Type-Options", "value": "nosniff" },
-        { "key": "X-Frame-Options", "value": "DENY" },
-        { "key": "Strict-Transport-Security", "value": "max-age=31536000; includeSubDomains" },
-        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
-        { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=()" }
+        {
+          "key": "X-Content-Type-Options",
+          "value": "nosniff"
+        },
+        {
+          "key": "X-Frame-Options",
+          "value": "DENY"
+        },
+        {
+          "key": "Strict-Transport-Security",
+          "value": "max-age=31536000; includeSubDomains"
+        },
+        {
+          "key": "Referrer-Policy",
+          "value": "strict-origin-when-cross-origin"
+        },
+        {
+          "key": "Permissions-Policy",
+          "value": "camera=(), microphone=(), geolocation=()"
+        }
       ]
     },
     {
       "source": "/data/(.*)",
       "headers": [
-        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
       ]
     },
     {
       "source": "/assets/(.*)",
       "headers": [
-        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=31536000, immutable"
+        }
+      ]
+    },
+    {
+      "source": "/export/(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=3600"
+        }
       ]
     },
     {
       "source": "/robots.txt",
       "headers": [
-        { "key": "Cache-Control", "value": "public, max-age=86400" }
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=86400"
+        }
       ]
     },
     {
       "source": "/sitemap.xml",
       "headers": [
-        { "key": "Cache-Control", "value": "public, max-age=86400" }
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=86400"
+        }
       ]
     },
     {
       "source": "/llms.txt",
       "headers": [
-        { "key": "Cache-Control", "value": "public, max-age=86400" }
+        {
+          "key": "Cache-Control",
+          "value": "public, max-age=86400"
+        }
       ]
     }
   ]


### PR DESCRIPTION
Closes #7

## O que muda

O build passa a escrever `public/export/`:

| | Por conversa | Tudo |
|---|---|---|
| **Markdown** | `masterwhats-<id>.md` | `masterwhats.md` (3,1 MB) |
| **JSON** | `masterwhats-<id>.json` | `masterwhats.json` (13,5 MB) |
| **Zip** | — | `masterwhats-export.zip` (2,7 MB): os 24 pares + `README.md` |

O `.md` se explica sozinho: proveniência (fonte, documento e sha256 completo do PDF, período, fuso), "Quem é" o contato com as fontes como links, e as mensagens dia a dia — as do laudo citam `laudo p. N, fig. M`. O `.json` traz os mesmos metadados e perfil, todas as mensagens com os campos originais e `timestamp` com fuso (`-03:00`).

Na interface: **Exportar (.md)** e **Exportar (.json)** no menu de cada chat; **Exportar tudo (.zip)** no menu `⋮` da lista de conversas. Esse menu estava escondido no desktop — o WhatsApp Web o tem, e era a única casa possível pro zip nos dois layouts, então agora aparece nos dois.

## Decisões

- **Script em Node, não Python.** Os perfis moram em `profile-content.js`; importar de lá mantém export e site dizendo a mesma coisa. Uma dependência de build (`jszip`).
- **Roda depois do `split-data`** e lê a lista de conversas de `public/data/conversations.json` — não deriva ids de novo.
- **Sem escapes agressivos** no Markdown: só `#`, `>`, `-` no início de linha, pra texto de chat continuar legível cru (é o que modelo lê).

## Testes

- `export-data.test.js`: cada mensagem presente, todo timestamp com fuso, toda mensagem do laudo com página, nenhum markup do site sobrando (`{texto}[url]`, `[action:`), zip com README e os 48 arquivos.
- `export.test.js`: URLs e o download com o nome do arquivo.
- `export.test.js` (E2E): os dois menus, o nome do arquivo baixado, o menu fechando, e **o menu do chat com dois itens a mais cabendo na tela do celular**.
- `share.test.js` atualizado: lista de itens do menu ganhou os dois novos.

170 → 187 unit, 237 → 249 E2E.

## Serve também

- **#9 (GEO):** os `.md` por conversa são o que `llms-full.txt` vai apontar; `llms.txt` já linka o export.
- **#8 (API/MCP):** os `.json` planos são o corpo das respostas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RPgDUnTk2JuejAso8UHMWb