### PR TITLE
Print: voltar fecha o modal no Android; barra com o site em todo print

### DIFF
--- a/src/components/ImagePreview.js
+++ b/src/components/ImagePreview.js
@@ -13,9 +13,17 @@
  * The image stays on screen because a long press on it opens the browser's own
  * menu, which copies, saves and shares.
  *
+ * On Android the back button is how people leave a sheet, and here it used to
+ * leave the conversation instead: the router saw a hash change and went to the
+ * list. So opening pushes a history entry and closing pops it — back closes
+ * the preview and nothing else. Closing by the X or Escape pops the same entry,
+ * or the next back press would jump one step too far.
+ *
  * Security note: innerHTML is used only with static markup; the image arrives
  * as an object URL, assigned through the src property.
  */
+
+const HISTORY_MARK = { masterwhatsImagePreview: true };
 
 const ICON_CLOSE = `<svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>`;
 
@@ -94,10 +102,23 @@ export function showImagePreview(container, blob, { filename, onShare, onClose }
     download();
   }
 
+  function ownsHistoryEntry() {
+    return typeof history !== 'undefined' && !!history.state?.masterwhatsImagePreview;
+  }
+
+  function onPopstate() {
+    // Back was pressed: our entry is already gone, so just close.
+    window.removeEventListener('popstate', onPopstate);
+    close();
+  }
+
   function destroy() {
     document.removeEventListener('keydown', onKeydown, true);
+    window.removeEventListener('popstate', onPopstate);
     overlay.remove();
     URL.revokeObjectURL(url);
+    // Closed by the X, Escape or the backdrop: take our entry with us.
+    if (ownsHistoryEntry()) history.back();
   }
 
   function close() {
@@ -116,6 +137,10 @@ export function showImagePreview(container, blob, { filename, onShare, onClose }
     if (e.target === overlay) close();
   });
   document.addEventListener('keydown', onKeydown, true);
+  if (typeof history !== 'undefined') {
+    history.pushState(HISTORY_MARK, '');
+    window.addEventListener('popstate', onPopstate);
+  }
 
   container.appendChild(overlay);
   requestAnimationFrame(() => overlay.classList.add('open'));

--- a/src/lib/screenshot.js
+++ b/src/lib/screenshot.js
@@ -165,14 +165,78 @@ function inlineStylesheets(clonedDoc) {
   clonedDoc.head.appendChild(style);
 }
 
+/** Height, in CSS pixels, of the bar with the site's address under every print. */
+export const ATTRIBUTION_BAR_HEIGHT = 44;
+const ATTRIBUTION_URL = 'www.masterwhats.com.br';
+const ATTRIBUTION_NAME = 'MasterWhats';
+const ATTRIBUTION_LOGO = '/assets/masterzap-logo.png';
+
+function loadImage(src) {
+  return new Promise((resolve) => {
+    const img = new Image();
+    img.onload = () => resolve(img);
+    img.onerror = () => resolve(null);
+    img.src = src;
+  });
+}
+
 /**
- * Render an element to a PNG blob, clipped to what is visible.
+ * Add a bar under the picture saying where it came from — the way a
+ * screenshot shared from Reddit carries "Posted in r/…". A print travels
+ * further than a link does, and this is the only thing on it that says where
+ * the rest of the conversation is.
+ *
+ * @param {HTMLCanvasElement} canvas - the rendered chat
+ * @param {number} scale - device pixels per CSS pixel the canvas was drawn at
+ * @returns {Promise<HTMLCanvasElement>}
+ */
+async function withAttributionBar(canvas, scale) {
+  const barHeight = Math.round(ATTRIBUTION_BAR_HEIGHT * scale);
+  const out = document.createElement('canvas');
+  out.width = canvas.width;
+  out.height = canvas.height + barHeight;
+  const ctx = out.getContext('2d');
+  // No 2D context means no browser (jsdom); the picture goes out as it is.
+  if (!ctx) return canvas;
+
+  ctx.drawImage(canvas, 0, 0);
+
+  const top = canvas.height;
+  const middle = top + barHeight / 2;
+  const pad = 16 * scale;
+  ctx.fillStyle = '#111b21';
+  ctx.fillRect(0, top, out.width, barHeight);
+
+  ctx.textBaseline = 'middle';
+  ctx.fillStyle = '#e9edef';
+  ctx.font = `500 ${15 * scale}px Roboto, "Helvetica Neue", Arial, sans-serif`;
+  ctx.textAlign = 'left';
+  ctx.fillText(ATTRIBUTION_URL, pad, middle);
+
+  // Logo and name on the right; the name alone if the logo does not load.
+  const logo = await loadImage(ATTRIBUTION_LOGO);
+  const logoSize = 26 * scale;
+  ctx.textAlign = 'right';
+  ctx.font = `700 ${15 * scale}px Roboto, "Helvetica Neue", Arial, sans-serif`;
+  const nameRight = out.width - pad;
+  ctx.fillText(ATTRIBUTION_NAME, nameRight, middle);
+  if (logo) {
+    const nameWidth = ctx.measureText(ATTRIBUTION_NAME).width;
+    ctx.drawImage(logo, nameRight - nameWidth - 8 * scale - logoSize, middle - logoSize / 2, logoSize, logoSize);
+  }
+  return out;
+}
+
+/**
+ * Render an element to a PNG blob, clipped to what is visible, with the
+ * attribution bar underneath.
  * @param {HTMLElement} element
  * @returns {Promise<Blob>}
  */
 export async function captureElement(element) {
   const html2canvas = await loadHtml2Canvas();
   const rect = element.getBoundingClientRect();
+  const scale = Math.min(window.devicePixelRatio || 1, 2);
 
   const canvas = await html2canvas(element, {
     // The dropdown that started this sits inside the captured area; the picture
@@ -181,7 +245,7 @@ export async function captureElement(element) {
     onclone: inlineStylesheets,
     // Cap the pixel ratio: a 3x phone screen would otherwise produce an image
     // several times larger than anything needs.
-    scale: Math.min(window.devicePixelRatio || 1, 2),
+    scale,
     backgroundColor: null,
     useCORS: true,
     logging: false,
@@ -194,7 +258,8 @@ export async function captureElement(element) {
     scrollY: 0,
   });
 
-  const blob = await new Promise(resolve => canvas.toBlob(resolve, 'image/png'));
+  const framed = await withAttributionBar(canvas, scale);
+  const blob = await new Promise(resolve => framed.toBlob(resolve, 'image/png'));
   if (!blob) throw new Error('Não foi possível gerar a imagem.');
   return blob;
 }

--- a/tests/e2e/image-preview.test.js
+++ b/tests/e2e/image-preview.test.js
@@ -189,3 +189,41 @@ test.describe('Dismissing the preview', () => {
     await expect(page.locator('.image-preview')).toBeVisible();
   });
 });
+
+test.describe('The back button', () => {
+  // On Android, back is how a sheet gets dismissed. It used to leave the
+  // conversation: the router saw the hash change and went to the list.
+  test('closes the preview and stays in the conversation', async ({ page }) => {
+    await page.goto('/');
+    await page.goto('/#/chat/ciro-soares');
+    await expect(page.locator('.chat-msg-bubble').first()).toBeVisible();
+    await page.evaluate(FIREFOX_PROFILE);
+    await page.locator('.chat-header button[aria-label="Menu"]').click();
+    await page.locator('.chat-dropdown-item', { hasText: 'Compartilhar print' }).click();
+    await expect(page.locator('.image-preview')).toBeVisible({ timeout: 20000 });
+
+    await page.goBack();
+
+    await expect(page.locator('.image-preview')).toHaveCount(0);
+    await expect(page.locator('.chat-msg-bubble').first()).toBeVisible();
+    expect(await page.evaluate(() => location.hash)).toBe('#/chat/ciro-soares');
+  });
+
+  // Closing on the X must not leave the extra entry behind, or the next back
+  // press would go nowhere.
+  test('after closing on the X, back leaves the conversation as before', async ({ page }) => {
+    await page.goto('/#/');
+    await page.goto('/#/chat/ciro-soares');
+    await expect(page.locator('.chat-msg-bubble').first()).toBeVisible();
+    await page.evaluate(FIREFOX_PROFILE);
+    await page.locator('.chat-header button[aria-label="Menu"]').click();
+    await page.locator('.chat-dropdown-item', { hasText: 'Compartilhar print' }).click();
+    await expect(page.locator('.image-preview')).toBeVisible({ timeout: 20000 });
+
+    await page.locator('.image-preview-close').click();
+    await expect(page.locator('.image-preview')).toHaveCount(0);
+
+    await page.goBack();
+    await expect.poll(() => page.evaluate(() => location.hash)).toBe('#/');
+  });
+});

--- a/tests/e2e/screenshot.test.js
+++ b/tests/e2e/screenshot.test.js
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { ATTRIBUTION_BAR_HEIGHT } from '../../src/lib/screenshot.js';
 
 // The capture itself only exists in a real browser: html2canvas walks the live
 // DOM and paints it into a canvas. The delivery chain is unit-tested; what is
@@ -72,7 +73,8 @@ test.describe('Chat screenshot', () => {
 
     const area = await page.locator('.main-area').boundingBox();
     const ratio = size.width / size.height;
-    const expected = area.width / area.height;
+    // The bar with the site's address sits under the chat.
+    const expected = area.width / (area.height + ATTRIBUTION_BAR_HEIGHT);
 
     // Rendered at devicePixelRatio, so compare shape rather than pixel counts.
     expect(Math.abs(ratio - expected)).toBeLessThan(0.05);
@@ -98,7 +100,40 @@ test.describe('Chat screenshot', () => {
       .evaluate(el => el.scrollHeight);
     const dpr = await page.evaluate(() => Math.min(window.devicePixelRatio || 1, 2));
 
-    expect(height / dpr).toBeLessThan(scrollHeight);
+    expect(height / dpr - ATTRIBUTION_BAR_HEIGHT).toBeLessThan(scrollHeight);
+  });
+
+  // A print travels further than a link; the bar is the only thing on it that
+  // says where the conversation lives.
+  test('carries the site address in a bar at the bottom', async ({ page }) => {
+    const dataUrl = await captureProducedImage(page);
+    const dpr = await page.evaluate(() => Math.min(window.devicePixelRatio || 1, 2));
+
+    const rows = await page.evaluate(([src, barCss, scale]) => new Promise(resolve => {
+      const img = new Image();
+      img.onload = () => {
+        const c = document.createElement('canvas');
+        c.width = img.naturalWidth; c.height = img.naturalHeight;
+        const ctx = c.getContext('2d');
+        ctx.drawImage(img, 0, 0);
+        const bar = Math.round(barCss * scale);
+        const mean = (y0, y1) => {
+          const { data } = ctx.getImageData(0, y0, c.width, y1 - y0);
+          let sum = 0;
+          for (let i = 0; i < data.length; i += 4) sum += (data[i] + data[i + 1] + data[i + 2]) / 3;
+          return sum / (data.length / 4);
+        };
+        resolve({
+          bar: mean(c.height - bar + 2, c.height - 2),
+          chatAbove: mean(c.height - bar - 40, c.height - bar - 2),
+        });
+      };
+      img.src = src;
+    }), [dataUrl, ATTRIBUTION_BAR_HEIGHT, dpr]);
+
+    // Dark bar under a light chat.
+    expect(rows.bar).toBeLessThan(70);
+    expect(rows.chatAbove).toBeGreaterThan(rows.bar + 60);
   });
 
   test('confirms with a toast when it lands on the clipboard', async ({ page, context, browserName }) => {


### PR DESCRIPTION
## Voltar fecha o print

No Android, o botão voltar é como se sai de uma folha — e aqui ele saía da conversa: o router via o hash mudar e ia pra lista. Abrir o preview agora empurra uma entrada no histórico e fechar a retira. Fechar pelo X, Escape ou fundo retira a mesma entrada, senão o próximo voltar pularia um passo a mais.

Testes (mobile e desktop): voltar fecha o modal e fica no chat com o hash intacto; depois de fechar no X, voltar leva pra onde levaria antes.

## Barra de atribuição

Todo print ganha embaixo uma barra escura com `www.masterwhats.com.br` à esquerda e logo + nome à direita, como o "Posted in r/…" do Reddit. Desenhada no canvas depois do html2canvas, na mesma escala do print. Sem contexto 2D (jsdom) a imagem segue sem barra.

`ATTRIBUTION_BAR_HEIGHT` é exportado; o teste de enquadramento conta com ele, e um teste novo confere a banda escura sob o chat claro.

199 unit, 258 E2E (+6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RPgDUnTk2JuejAso8UHMWb