### PR TITLE
GEO: PDF fantasma, data em cada linha do .md, tamanhos reais no llms.txt

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -54,7 +54,7 @@ Comece pelo arquivo de uma conversa (7 a 40 KB); os consolidados são grandes e 
 - A mesma conversa em JSON: https://www.masterwhats.com.br/export/masterwhats-alexandre-de-moraes.json
 - Todas as conversas num arquivo: https://www.masterwhats.com.br/export/masterwhats.md (3 MB) e https://www.masterwhats.com.br/export/masterwhats.json (14 MB)
 - Zip com tudo: https://www.masterwhats.com.br/export/masterwhats-export.zip (3 MB)
-Cada .md abre com proveniência (fonte, documento com páginas e sha256, período, fuso UTC-3), o perfil do contato com fontes, e as mensagens dia a dia — cada linha com hora ao segundo e "msg n"; as do relatório da PF citam página e figura do laudo.
+Cada .md abre com proveniência (fonte, documento com páginas e sha256, período, fuso UTC-3), o perfil do contato com fontes, e as mensagens dia a dia — cada linha com data, hora ao segundo e "msg n" (basta um grep por "msg n"); as do relatório da PF citam página e figura do laudo.
 
 ## Como citar uma mensagem
 - Link direto no app: https://www.masterwhats.com.br/#/chat/<id>/msg/<n> — o n é o "msg n" do Markdown e o campo id do JSON

--- a/scripts/export.mjs
+++ b/scripts/export.mjs
@@ -115,7 +115,7 @@ function conversationMarkdown(entry, messages, { standalone = true } = {}) {
 
   out.push(`${sub} Proveniência`, '', '| | |', '|---|---|');
   out.push(`| Fonte | ${source.label} |`);
-  if (source.document) out.push(`| Documento | \`${source.document}\`${source.document_pages ? `, ${source.document_pages} páginas` : ''} (sha256 \`${source.document_sha256 || 'n/d'}\`) |`);
+  if (source.document) out.push(`| Documento | \`${source.document}\`${source.document_pages ? `, ${source.document_pages} páginas` : ''}${source.document_url ? ` — [no repositório](${source.document_url})` : ''} (sha256 \`${source.document_sha256 || 'n/d'}\`) |`);
   out.push(`| Como chegou ao público | ${source.how} |`);
   out.push(`| Período | ${entry.date_range.start} a ${entry.date_range.end} |`);
   out.push(`| Mensagens | ${entry.total_messages} |`);
@@ -137,7 +137,7 @@ function conversationMarkdown(entry, messages, { standalone = true } = {}) {
       out.push(`${standalone ? '###' : '####'} ${longDate(day)}`, '');
     }
     // Time to the second and the message id: the key a citation needs.
-    const tags = [msg.time, `msg ${msg.id}`];
+    const tags = [`${msg.date} ${msg.time}`, `msg ${msg.id}`];
     if (msg.is_edited) tags.push('editada');
     if (msg.view_once) tags.push('visualização única');
     if (msg.source_page) tags.push(`laudo p. ${msg.source_page}${msg.source_figure ? `, fig. ${msg.source_figure}` : ''}`);

--- a/scripts/lib/corpus.mjs
+++ b/scripts/lib/corpus.mjs
@@ -47,6 +47,7 @@ export function sourceOf(entry) {
       kind: 'police-report',
       label: entry.source,
       document: doc.file || null,
+      document_url: doc.url || null,
       document_sha256: doc.sha256 || null,
       document_pages: doc.pages || null,
       made_public: '2026-09-01',

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -16,7 +16,7 @@
  * the article as its first act.
  */
 
-import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { readFileSync, writeFileSync, mkdirSync, existsSync, statSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { getContactProfile, VORCARO_PROFILE, SOURCES } from '../src/lib/profile-content.js';
@@ -50,6 +50,7 @@ function reportDoc(source) {
     datePublished: '2026-08-27',
   };
   if (source.document_pages) doc.numberOfPages = source.document_pages;
+  if (source.document_url) doc.url = source.document_url;
   if (source.document_sha256) {
     doc.identifier = { '@type': 'PropertyValue', propertyID: 'sha256', value: source.document_sha256 };
   }
@@ -109,7 +110,7 @@ function article(entry, messages, profile, who) {
 
   out.push('<h2>Proveniência</h2><dl>');
   out.push(`<dt>Fonte</dt><dd>${escapeHtml(source.label)}</dd>`);
-  if (source.document) out.push(`<dt>Documento</dt><dd>${escapeHtml(source.document)}${source.document_pages ? `, ${source.document_pages} páginas` : ''}</dd>`);
+  if (source.document) out.push(`<dt>Documento</dt><dd>${source.document_url ? `<a href="${escapeHtml(source.document_url)}" rel="noopener">${escapeHtml(source.document)}</a>` : escapeHtml(source.document)}${source.document_pages ? `, ${source.document_pages} páginas` : ''} (no repositório; o site não serve o PDF)</dd>`);
   if (source.document_sha256) out.push(`<dt>sha256 do documento</dt><dd><code>${source.document_sha256}</code></dd>`);
   out.push(`<dt>Como chegou ao público</dt><dd>${escapeHtml(source.how)}</dd>`);
   if (entry.saved_as) out.push(`<dt>Contato salvo como</dt><dd>${escapeHtml(entry.saved_as)}</dd>`);
@@ -265,6 +266,12 @@ for (const entry of entries) {
   built.push({ entry, who, profile });
   console.log(`chat/${entry.id}/ — ${who}`);
 }
-writeFileSync(join(DIST, 'llms-full.txt'), llmsFull(built));
+// The sizes the index quotes decide whether a crawler downloads a file. They
+// are stamped from the files themselves rather than typed and forgotten.
+const mb = (name) => `${(statSync(join(DIST, 'export', name)).size / 1048576).toFixed(1)} MB`;
+const SIZES = { 'masterwhats.md': mb('masterwhats.md'), 'masterwhats.json': mb('masterwhats.json'), 'masterwhats-export.zip': mb('masterwhats-export.zip') };
+const stampSizes = (text) => text.replace(/(masterwhats(?:-export)?\.(?:md|json|zip)) \([\d.,]+ MB\)/g, (m, name) => `${name} (${SIZES[name] || m.slice(name.length + 2, -1)})`);
+writeFileSync(join(DIST, 'llms.txt'), stampSizes(readFileSync(join(DIST, 'llms.txt'), 'utf-8')));
+writeFileSync(join(DIST, 'llms-full.txt'), stampSizes(llmsFull(built)));
 writeFileSync(join(DIST, 'sitemap.xml'), sitemap(built));
 console.log(`\nDone! ${built.length} pages, llms-full.txt, sitemap.xml → ${DIST}`);

--- a/scripts/split_data.py
+++ b/scripts/split_data.py
@@ -147,7 +147,13 @@ def describe_report_document():
             pages = int(m.group(1))
     except (OSError, subprocess.SubprocessError):
         pass
-    return {"file": REPORT_PDF, "sha256": sha, "pages": pages}
+    # The path is the repository's; the site does not serve the PDF. Say where it is.
+    return {
+        "file": REPORT_PDF,
+        "url": f"https://github.com/rafaelbressan/masterzap/blob/main/{REPORT_PDF}",
+        "sha256": sha,
+        "pages": pages,
+    }
 
 
 def normalise_date_range(date_range):

--- a/tests/unit/conversations-data.test.js
+++ b/tests/unit/conversations-data.test.js
@@ -140,6 +140,7 @@ describe('the police report as a document', () => {
       expect(conv.source_document?.sha256, conv.id).toMatch(/^[0-9a-f]{64}$/);
       expect(conv.source_document?.pages, conv.id).toBeGreaterThan(0);
       expect(conv.source_document?.file, conv.id).toMatch(/\.pdf$/);
+      expect(conv.source_document?.url, conv.id).toMatch(/^https:\/\/github\.com\/.*\.pdf$/);
     }
   });
 

--- a/tests/unit/export-data.test.js
+++ b/tests/unit/export-data.test.js
@@ -101,18 +101,19 @@ describe('the Markdown', () => {
     expect(text).toContain('](https://www.masterwhats.com.br/#/chat/alexandre-de-moraes/msg/');
     expect(text).toMatch(/⟨\d{2}\/\d{2}\/\d{4} \d{2}:\d{2} · laudo p\. \d+, fig\. \d+⟩/);
     expect(text).toContain('218 páginas');
+    expect(text).toContain('[no repositório](https://github.com/rafaelbressan/masterzap/blob/main/data/source/');
   });
 
   it('cites the page of the report on every message from it', () => {
     const text = md('alexandre-de-moraes');
-    const headers = text.split('\n').filter(l => /^\*\*.+\*\* · \d{2}:\d{2}:\d{2} · msg \d+/.test(l));
+    const headers = text.split('\n').filter(l => /^\*\*.+\*\* · \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} · msg \d+/.test(l));
     expect(headers.length).toBe(62);
     for (const line of headers) expect(line).toMatch(/laudo p\. \d+/);
   });
 
   it('keeps every message', () => {
     for (const conv of conversations) {
-      const headers = md(conv.id).split('\n').filter(l => /^\*\*.+\*\* · \d{2}:\d{2}:\d{2} · msg \d+/.test(l));
+      const headers = md(conv.id).split('\n').filter(l => /^\*\*.+\*\* · \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} · msg \d+/.test(l));
       expect(headers.length, conv.id).toBe(conv.total_messages);
     }
   });

--- a/tests/unit/prerender.test.js
+++ b/tests/unit/prerender.test.js
@@ -5,7 +5,7 @@
 // `npm run build` comes first.
 
 import { describe, it, expect } from 'vitest';
-import { readFileSync, existsSync } from 'fs';
+import { readFileSync, existsSync, statSync } from 'fs';
 import { join } from 'path';
 
 const ROOT = join(import.meta.dirname, '../..');
@@ -47,6 +47,9 @@ describe('one page per conversation', () => {
     const html = page('ciro-soares');
     expect(html).toContain('218 páginas');
     expect(html).toMatch(/<dt>sha256 do documento<\/dt><dd><code>[0-9a-f]{64}<\/code><\/dd>/);
+    // The path is the repository's; a crawler must not fetch it from the site.
+    expect(html).toContain('href="https://github.com/rafaelbressan/masterzap/blob/main/data/source/');
+    expect(html).toContain('o site não serve o PDF');
     const [ld] = ldBlocks(html);
     expect(ld.isBasedOn.numberOfPages).toBe(218);
     expect(ld.isBasedOn.identifier.value).toMatch(/^[0-9a-f]{64}$/);
@@ -121,6 +124,14 @@ describe('the home page', () => {
     const dataset = blocks.find(b => b['@type'] === 'Dataset');
     expect(dataset['@id']).toBe(`${SITE}/#dataset`);
     expect(dataset.distribution.map(d => d.contentUrl)).toContain(`${SITE}/export/masterwhats-export.zip`);
+  });
+});
+
+describe('llms.txt', () => {
+  it('quotes the real size of the big files', () => {
+    const t = readFileSync(join(DIST, 'llms.txt'), 'utf-8');
+    const real = (statSync(join(DIST, 'export/masterwhats.md')).size / 1048576).toFixed(1);
+    expect(t).toContain(`masterwhats.md (${real} MB)`);
   });
 });
 


### PR DESCRIPTION
Do terceiro teste com agente-crawler (4/5, mesmas perguntas do segundo, que deu 3/5). Três reparos:

- **PDF fantasma.** A proveniência citava `data/source/IPJ-A-3298613-2026.pdf` como `file`, e esse caminho no site devolve o `index.html` com 200 — um crawler baixava HTML achando que era o laudo. O arquivo é do repositório e agora diz isso: `split_data.py` registra `source_document.url` (GitHub), e `.md`, página `/chat/<id>` e JSON-LD (`isBasedOn.url`) apontam pra ela com "no repositório; o site não serve o PDF".
- **Data em cada linha do `.md`.** Só existia no cabeçalho da seção; `grep "msg 35686"` dava hora sem dia. Agora `**DV** · 2024-12-04 00:33:42 · msg 35686`. O da Martha vai de 3 pra 5 MB; cada linha se basta.
- **Tamanhos reais.** `llms.txt` dizia "3 MB" de um arquivo de 4,5. O prerender carimba os tamanhos de `masterwhats.md/.json/.zip` a partir dos arquivos, no `llms.txt` e no `llms-full.txt`; um teste compara com o disco.

217 unit, 258 E2E.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RPgDUnTk2JuejAso8UHMWb