### PR TITLE
Página por mês na Martha, índice de pessoas, citações com âncora estática (#14, #15)

### DIFF
--- a/index.html
+++ b/index.html
@@ -151,20 +151,20 @@
       <p>Busca com suporte a acentos, compartilhamento de trechos via link direto, navegação por data com calendário, perfil de cada contato com contexto investigativo e fontes, e links internos que levam aos trechos citados pela imprensa.</p>
       <h2>Destaques: o relatório sobre Alexandre de Moraes</h2>
       <ul>
-        <li>"<a href="/#/chat/alexandre-de-moraes/msg/39">Acha que segunda ja tenho que estar fora?</a>" — dois dias antes da prisão <small>⟨15/11/2025 18:22 · laudo p. 109, fig. 108⟩</small></li>
-        <li>"<a href="/#/chat/alexandre-de-moraes/msg/9">É importante reforçar com Andrei e Paulo pra nao deixar ninguem de baixo fazer uma sacanagem</a>" — sobre o diretor-geral da PF e o procurador-geral <small>⟨30/10/2025 13:33 · laudo p. 49, fig. 48⟩</small></li>
-        <li>"<a href="/#/chat/alexandre-de-moraes/msg/38">Voce sabe que tenho gratidao da minha vida a você</a>" — três dias antes da prisão <small>⟨14/11/2025 18:19 · laudo p. 107, fig. 106⟩</small></li>
-        <li>"<a href="/#/chat/romy-banco-master/msg/6">Pode pagar sempre, sem nota</a>" — Vorcaro à diretoria, sobre o contrato do escritório Barci de Moraes <small>⟨15/03/2024 15:19 · laudo p. 153, fig. 152⟩</small></li>
-        <li>"<a href="/#/chat/ana-matos-mkt/msg/74">Alexandre morre se vc fizer isso</a>" — sobre um convidado vetado no fórum jurídico de Londres <small>⟨18/07/2025 17:29 · laudo p. 193, fig. 202⟩</small></li>
+        <li>"<a href="/chat/alexandre-de-moraes#msg-39">Acha que segunda ja tenho que estar fora?</a>" — dois dias antes da prisão <small>⟨15/11/2025 18:22 · laudo p. 109, fig. 108⟩</small></li>
+        <li>"<a href="/chat/alexandre-de-moraes#msg-9">É importante reforçar com Andrei e Paulo pra nao deixar ninguem de baixo fazer uma sacanagem</a>" — sobre o diretor-geral da PF e o procurador-geral <small>⟨30/10/2025 13:33 · laudo p. 49, fig. 48⟩</small></li>
+        <li>"<a href="/chat/alexandre-de-moraes#msg-38">Voce sabe que tenho gratidao da minha vida a você</a>" — três dias antes da prisão <small>⟨14/11/2025 18:19 · laudo p. 107, fig. 106⟩</small></li>
+        <li>"<a href="/chat/romy-banco-master#msg-6">Pode pagar sempre, sem nota</a>" — Vorcaro à diretoria, sobre o contrato do escritório Barci de Moraes <small>⟨15/03/2024 15:19 · laudo p. 153, fig. 152⟩</small></li>
+        <li>"<a href="/chat/ana-matos-mkt#msg-74">Alexandre morre se vc fizer isso</a>" — sobre um convidado vetado no fórum jurídico de Londres <small>⟨18/07/2025 17:29 · laudo p. 193, fig. 202⟩</small></li>
       </ul>
       <h2>Destaques: as conversas com Martha Graeff</h2>
       <ul>
-        <li>"<a href="/#/chat/martha-graeff/msg/50236">Fala que eu sou a anarquia do sistema</a>" — Vorcaro sobre si mesmo <small>⟨31/03/2025 18:18⟩</small></li>
-        <li>"<a href="/#/chat/martha-graeff/msg/13984">Peleleca vai estar cabelo branco</a>" — apelido que viralizou nas redes <small>⟨28/07/2024 16:47⟩</small></li>
-        <li>"<a href="/#/chat/martha-graeff/msg/50835">Andre disse que era o maior banqueiro do mundo</a>" — sobre André Esteves <small>⟨04/04/2025 22:14⟩</small></li>
-        <li>"<a href="/#/chat/martha-graeff/msg/35686">Acredita que o presidente bacen ja falou da nossa casa</a>" — casa de Miami <small>⟨04/12/2024 00:33⟩</small></li>
-        <li>"<a href="/#/chat/martha-graeff/msg/12383">O pior de ontem foi ter o bolsonaro</a>" — Vorcaro sobre Bolsonaro <small>⟨13/07/2024 12:17⟩</small></li>
-        <li>"<a href="/#/chat/martha-graeff/msg/19438">Fiquei ali de amante pra nada?</a>" — Martha sobre o início da relação <small>⟨29/08/2024 23:05⟩</small></li>
+        <li>"<a href="/chat/martha-graeff/2025-03#msg-50236">Fala que eu sou a anarquia do sistema</a>" — Vorcaro sobre si mesmo <small>⟨31/03/2025 18:18⟩</small></li>
+        <li>"<a href="/chat/martha-graeff/2024-07#msg-13984">Peleleca vai estar cabelo branco</a>" — apelido que viralizou nas redes <small>⟨28/07/2024 16:47⟩</small></li>
+        <li>"<a href="/chat/martha-graeff/2025-04#msg-50835">Andre disse que era o maior banqueiro do mundo</a>" — sobre André Esteves <small>⟨04/04/2025 22:14⟩</small></li>
+        <li>"<a href="/chat/martha-graeff/2024-12#msg-35686">Acredita que o presidente bacen ja falou da nossa casa</a>" — casa de Miami <small>⟨04/12/2024 00:33⟩</small></li>
+        <li>"<a href="/chat/martha-graeff/2024-07#msg-12383">O pior de ontem foi ter o bolsonaro</a>" — Vorcaro sobre Bolsonaro <small>⟨13/07/2024 12:17⟩</small></li>
+        <li>"<a href="/chat/martha-graeff/2024-08#msg-19438">Fiquei ali de amante pra nada?</a>" — Martha sobre o início da relação <small>⟨29/08/2024 23:05⟩</small></li>
       </ul>
       <h2>Fontes</h2>
       <ul>

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -27,25 +27,26 @@ Se outros vazamentos vierem a público, entram como mais uma conversa.
 Daniel Vorcaro, dono do Banco Master, foi preso pela Polícia Federal em novembro de 2025 após o maior escândalo bancário da história do Brasil.
 
 ## Destaques: o relatório sobre Alexandre de Moraes
-- "Acha que segunda ja tenho que estar fora?" — dois dias antes da prisão — https://www.masterwhats.com.br/#/chat/alexandre-de-moraes/msg/39 ⟨15/11/2025 18:22 · laudo p. 109, fig. 108⟩
-- "É importante reforçar com Andrei e Paulo pra nao deixar ninguem de baixo fazer uma sacanagem" — sobre o diretor-geral da PF e o procurador-geral da República — https://www.masterwhats.com.br/#/chat/alexandre-de-moraes/msg/9 ⟨30/10/2025 13:33 · laudo p. 49, fig. 48⟩
-- "Voce sabe que tenho gratidao da minha vida a você" — depois de um encontro presencial, três dias antes da prisão — https://www.masterwhats.com.br/#/chat/alexandre-de-moraes/msg/38 ⟨14/11/2025 18:19 · laudo p. 107, fig. 106⟩
-- "Pode pagar sempre, sem nota" — Vorcaro à diretoria, sobre o contrato de R$ 208 milhões com o escritório Barci de Moraes — https://www.masterwhats.com.br/#/chat/romy-banco-master/msg/6 ⟨15/03/2024 15:19 · laudo p. 153, fig. 152⟩
-- "Alexandre morre se vc fizer isso" — sobre um convidado vetado no fórum jurídico de Londres bancado pelo banco — https://www.masterwhats.com.br/#/chat/ana-matos-mkt/msg/74 ⟨18/07/2025 17:29 · laudo p. 193, fig. 202⟩
-- "O Gonet perguntou se o filho dele pode ir com a gente para Londres?" — o procurador-geral nas tratativas do evento — https://www.masterwhats.com.br/#/chat/ciro-soares/msg/34 ⟨29/03/2025 13:58 · laudo p. 207, fig. 219⟩
+- "Acha que segunda ja tenho que estar fora?" — dois dias antes da prisão — https://www.masterwhats.com.br/chat/alexandre-de-moraes#msg-39 ⟨15/11/2025 18:22 · laudo p. 109, fig. 108⟩
+- "É importante reforçar com Andrei e Paulo pra nao deixar ninguem de baixo fazer uma sacanagem" — sobre o diretor-geral da PF e o procurador-geral da República — https://www.masterwhats.com.br/chat/alexandre-de-moraes#msg-9 ⟨30/10/2025 13:33 · laudo p. 49, fig. 48⟩
+- "Voce sabe que tenho gratidao da minha vida a você" — depois de um encontro presencial, três dias antes da prisão — https://www.masterwhats.com.br/chat/alexandre-de-moraes#msg-38 ⟨14/11/2025 18:19 · laudo p. 107, fig. 106⟩
+- "Pode pagar sempre, sem nota" — Vorcaro à diretoria, sobre o contrato de R$ 208 milhões com o escritório Barci de Moraes — https://www.masterwhats.com.br/chat/romy-banco-master#msg-6 ⟨15/03/2024 15:19 · laudo p. 153, fig. 152⟩
+- "Alexandre morre se vc fizer isso" — sobre um convidado vetado no fórum jurídico de Londres bancado pelo banco — https://www.masterwhats.com.br/chat/ana-matos-mkt#msg-74 ⟨18/07/2025 17:29 · laudo p. 193, fig. 202⟩
+- "O Gonet perguntou se o filho dele pode ir com a gente para Londres?" — o procurador-geral nas tratativas do evento — https://www.masterwhats.com.br/chat/ciro-soares#msg-34 ⟨29/03/2025 13:58 · laudo p. 207, fig. 219⟩
 
 ## Destaques: as conversas com Martha Graeff
-- "Fala que eu sou a anarquia do sistema" — Vorcaro sobre si mesmo — https://www.masterwhats.com.br/#/chat/martha-graeff/msg/50236 ⟨31/03/2025 18:18⟩
-- "Peleleca vai estar cabelo branco e eu chupando" — apelido que viralizou — https://www.masterwhats.com.br/#/chat/martha-graeff/msg/13984 ⟨28/07/2024 16:47⟩
-- "Andre disse que era o maior banqueiro do mundo" — sobre André Esteves (BTG) — https://www.masterwhats.com.br/#/chat/martha-graeff/msg/50835 ⟨04/04/2025 22:14⟩
-- "Eu tenho provas de quase todas" — Vorcaro sobre políticos — https://www.masterwhats.com.br/#/chat/martha-graeff/msg/50859 ⟨04/04/2025 22:21⟩
-- "Fiquei ali de amante pra nada?" — Martha sobre o início da relação — https://www.masterwhats.com.br/#/chat/martha-graeff/msg/19438 ⟨29/08/2024 23:05⟩
-- "Acredita que o presidente bacen ja falou da nossa casa" — sobre a casa de Miami — https://www.masterwhats.com.br/#/chat/martha-graeff/msg/35686 ⟨04/12/2024 00:33⟩
-- "O pior de ontem foi ter o bolsonaro" — Vorcaro sobre Bolsonaro — https://www.masterwhats.com.br/#/chat/martha-graeff/msg/12383 ⟨13/07/2024 12:17⟩
+- "Fala que eu sou a anarquia do sistema" — Vorcaro sobre si mesmo — https://www.masterwhats.com.br/chat/martha-graeff/2025-03#msg-50236 ⟨31/03/2025 18:18⟩
+- "Peleleca vai estar cabelo branco e eu chupando" — apelido que viralizou — https://www.masterwhats.com.br/chat/martha-graeff/2024-07#msg-13984 ⟨28/07/2024 16:47⟩
+- "Andre disse que era o maior banqueiro do mundo" — sobre André Esteves (BTG) — https://www.masterwhats.com.br/chat/martha-graeff/2025-04#msg-50835 ⟨04/04/2025 22:14⟩
+- "Eu tenho provas de quase todas" — Vorcaro sobre políticos — https://www.masterwhats.com.br/chat/martha-graeff/2025-04#msg-50859 ⟨04/04/2025 22:21⟩
+- "Fiquei ali de amante pra nada?" — Martha sobre o início da relação — https://www.masterwhats.com.br/chat/martha-graeff/2024-08#msg-19438 ⟨29/08/2024 23:05⟩
+- "Acredita que o presidente bacen ja falou da nossa casa" — sobre a casa de Miami — https://www.masterwhats.com.br/chat/martha-graeff/2024-12#msg-35686 ⟨04/12/2024 00:33⟩
+- "O pior de ontem foi ter o bolsonaro" — Vorcaro sobre Bolsonaro — https://www.masterwhats.com.br/chat/martha-graeff/2024-07#msg-12383 ⟨13/07/2024 12:17⟩
 
 ## Conteúdo completo em texto
 - https://www.masterwhats.com.br/llms-full.txt — sobre, os 24 perfis com fontes, os destaques, e o link do Markdown de cada conversa
-- Cada conversa tem página própria em https://www.masterwhats.com.br/chat/<id>, em HTML puro: proveniência, perfil com fontes e todas as mensagens com página e figura do laudo (só a conversa com Martha Graeff, de 65 mil mensagens, mostra as 200 primeiras e aponta pro Markdown completo)
+- Cada conversa tem página própria em https://www.masterwhats.com.br/chat/<id>, em HTML puro: proveniência, perfil com fontes e todas as mensagens com página e figura do laudo. A conversa com Martha Graeff (65 mil mensagens) tem uma página por mês — https://www.masterwhats.com.br/chat/martha-graeff/2024-12 — listadas na página principal
+- Pessoas citadas: https://www.masterwhats.com.br/quem/ — uma página por pessoa (ex.: https://www.masterwhats.com.br/quem/paulo-gonet) com toda menção, por conversa, datada e apontando para a mensagem
 
 ## Export limpo
 Tudo que o site mostra, em texto, sem o site:
@@ -57,8 +58,13 @@ Comece pelo arquivo de uma conversa (7 a 40 KB); os consolidados são grandes e 
 Cada .md abre com proveniência (fonte, documento com páginas e sha256, período, fuso UTC-3), o perfil do contato com fontes, e as mensagens dia a dia — cada linha com data, hora ao segundo e "msg n" (basta um grep por "msg n"); as do relatório da PF citam página e figura do laudo.
 
 ## Como citar uma mensagem
-- Link direto no app: https://www.masterwhats.com.br/#/chat/<id>/msg/<n> — o n é o "msg n" do Markdown e o campo id do JSON
-- Na página https://www.masterwhats.com.br/chat/<id>, cada mensagem tem a âncora #msg-<n>
+- Página estática: https://www.masterwhats.com.br/chat/<id>#msg-<n> (na conversa com Martha Graeff, a página do mês: https://www.masterwhats.com.br/chat/martha-graeff/2024-12#msg-35686). Funciona sem JavaScript, e com JavaScript abre o app nessa mensagem
+- Rota do app: https://www.masterwhats.com.br/#/chat/<id>/msg/<n> — o n é o "msg n" do Markdown e o campo id do JSON
+
+## Documento-fonte do relatório da PF
+- Arquivo: data/source/IPJ-A-3298613-2026.pdf — 218 páginas
+- sha256: 23cfdfa410c47ab09cbb2b443965e3a3095d9bc3dc5fb266efff76d6f5192b60
+- Onde obter: https://github.com/rafaelbressan/masterzap/blob/main/data/source/IPJ-A-3298613-2026.pdf — o site não serve o PDF; https://www.masterwhats.com.br/data/source/... redireciona para o repositório
 - Os destaques abaixo e no llms-full.txt já trazem o link e ⟨data hora · laudo p., fig.⟩
 
 ## Fontes

--- a/scripts/export.mjs
+++ b/scripts/export.mjs
@@ -20,7 +20,7 @@ import { getContactProfile, VORCARO_PROFILE, SOURCES } from '../src/lib/profile-
 import { SETTINGS_CONTENT } from '../src/lib/settings-content.js';
 import {
   ROOT, SITE, REPO, TIMEZONE, UTC_OFFSET,
-  loadEntries, loadMessages, sourceOf, contactOf, whoIs, createResolver,
+  loadEntries, loadMessages, sourceOf, contactOf, whoIs, createResolver, createLocator,
   urlsIn, linksToMarkdown, longDate, phonePretty, MEDIA,
 } from './lib/corpus.mjs';
 
@@ -31,7 +31,8 @@ const generatedAt = new Date().toISOString();
 const entries = loadEntries();
 // Highlights point at messages; resolved once here, for every file below.
 const resolve = createResolver(entries);
-const md = (text, context) => linksToMarkdown(text, { resolve, context });
+const hrefFor = createLocator(entries);
+const md = (text, context) => linksToMarkdown(text, { resolve, context, hrefFor });
 
 // ── text helpers ───────────────────────────────────────────────────────────
 

--- a/scripts/lib/corpus.mjs
+++ b/scripts/lib/corpus.mjs
@@ -104,12 +104,37 @@ export function createResolver(entries) {
     }
     return cache.get(id);
   };
-  return function resolve(conversationId, term) {
+  function resolve(conversationId, term) {
     const needle = normalize(term);
     const msg = messagesOf(conversationId).find(m => normalize(m.content || '').includes(needle));
     if (!msg) throw new Error(`destaque sem mensagem: ${conversationId} "${term}"`);
     return { conversationId, msg };
-  };
+  }
+  resolve.messagesOf = messagesOf;
+  return resolve;
+}
+
+/**
+ * Every message that names a person, by conversation.
+ *
+ * @returns {Map<string, object[]>} conversation id → messages, in order; only
+ *   conversations with at least one mention
+ */
+export function mentionsOf(person, entries, messagesOf) {
+  const rules = person.aliases.map(a => ({
+    re: new RegExp(`(^|[^a-z0-9])${normalize(a.match)}([^a-z0-9]|$)`),
+    only: a.only ? new Set(a.only) : null,
+    unless: a.unless ? new RegExp(a.unless) : null,
+  }));
+  const found = new Map();
+  for (const entry of entries) {
+    const hits = messagesOf(entry.id).filter(m => {
+      const text = normalize(m.content || '');
+      return rules.some(r => (!r.only || r.only.has(entry.id)) && r.re.test(text) && !(r.unless && r.unless.test(text)));
+    });
+    if (hits.length) found.set(entry.id, hits);
+  }
+  return found;
 }
 
 const brDate = (iso) => `${iso.slice(8, 10)}/${iso.slice(5, 7)}/${iso.slice(0, 4)}`;
@@ -119,6 +144,27 @@ export function citationOf(msg) {
   const parts = [`${brDate(msg.date)} ${msg.time.slice(0, 5)}`];
   if (msg.source_page) parts.push(`laudo p. ${msg.source_page}${msg.source_figure ? `, fig. ${msg.source_figure}` : ''}`);
   return parts.join(' · ');
+}
+
+/**
+ * A conversation with more messages than this gets one static page per month;
+ * its main page shows the first ones and an index of the months.
+ */
+export const PREVIEW_MESSAGES = 200;
+export const isPaged = (entry) => entry.total_messages > PREVIEW_MESSAGES;
+
+/**
+ * Where a message's anchor lives in the static site: /chat/<id>, or the month
+ * page of a conversation too big for one. Returns a path, or null for a
+ * conversation the site does not have.
+ */
+export function createLocator(entries) {
+  const byId = new Map(entries.map(e => [e.id, e]));
+  return (conversationId, msg) => {
+    const entry = byId.get(conversationId);
+    if (!entry) return null;
+    return isPaged(entry) ? `/chat/${conversationId}/${msg.date.slice(0, 7)}#msg-${msg.id}` : `/chat/${conversationId}#msg-${msg.id}`;
+  };
 }
 
 export const messageUrl = (conversationId, msg) => `${SITE}/#/chat/${conversationId}/msg/${msg.id}`;
@@ -155,6 +201,11 @@ function targetOf(url, { resolve, context } = {}) {
  * @param {string} [opts.context] - conversation for `action:search:` links
  * @param {string} [opts.samePage] - in html, messages of this conversation
  *   are linked by anchor rather than by site URL
+ * @param {function} [opts.hrefFor] - where a message's anchor lives in the
+ *   static site: (conversationId, msg) => path, or null to fall back to the
+ *   app's hash route. A path is made absolute in Markdown.
+ * @param {string} [opts.fromPath] - the page being rendered; a link to an
+ *   anchor on that same page is written as just the fragment
  */
 export function renderLinks(text, opts = {}) {
   const mode = opts.mode || 'md';
@@ -174,8 +225,11 @@ export function renderLinks(text, opts = {}) {
       case 'external':
         out += link(label, target.url); break;
       case 'message': {
-        const href = (mode === 'html' && opts.samePage === target.conversationId)
-          ? `#msg-${target.msg.id}` : messageUrl(target.conversationId, target.msg);
+        let placed = opts.hrefFor?.(target.conversationId, target.msg) || null;
+        if (placed && opts.fromPath && placed.startsWith(`${opts.fromPath}#`)) placed = placed.slice(opts.fromPath.length);
+        if (placed && mode === 'md' && placed.startsWith('/')) placed = `${SITE}${placed}`;
+        const href = placed || ((mode === 'html' && opts.samePage === target.conversationId)
+          ? `#msg-${target.msg.id}` : messageUrl(target.conversationId, target.msg));
         out += link(label, href) + cite(target.msg); break;
       }
       case 'conversation':

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -1,15 +1,23 @@
 /**
- * Give every conversation a real page, and give crawlers the whole corpus.
+ * Give every conversation a real page, every person talked about an index,
+ * and crawlers the whole corpus.
  *
  * Runs after `vite build`, on top of dist/index.html, and writes:
  *
- *   dist/chat/<id>/index.html   the built app page, retitled for one
- *                               conversation, with the profile and the first
- *                               messages as plain HTML and a one-line script
- *                               that sets the hash so the app opens that chat
- *   dist/llms-full.txt          the site's text — about, profiles, highlights —
- *                               with a pointer to each conversation's Markdown
- *   dist/sitemap.xml            home, the 24 pages, the 24 Markdown exports
+ *   dist/chat/<id>/index.html         the built app page, retitled for one
+ *                                     conversation, with the profile and the
+ *                                     messages as plain HTML and a one-line
+ *                                     script that sets the hash so the app
+ *                                     opens that chat
+ *   dist/chat/<id>/<YYYY-MM>/         one page per month, for a conversation
+ *                                     too big to show whole (Martha's 65k)
+ *   dist/quem/<slug>/index.html       every mention of a person, by
+ *                                     conversation, dated, pointing at the
+ *                                     message — and dist/quem/ listing them
+ *   dist/llms-full.txt                the site's text — about, profiles,
+ *                                     highlights, people — with a pointer to
+ *                                     each conversation's Markdown
+ *   dist/sitemap.xml                  all of the above
  *
  * The router keeps its hash routes; nothing in the app changes. A crawler that
  * runs no JavaScript reads the article. A browser runs the app, which removes
@@ -21,11 +29,12 @@ import { join } from 'node:path';
 
 import { getContactProfile, VORCARO_PROFILE, SOURCES } from '../src/lib/profile-content.js';
 import { SETTINGS_CONTENT } from '../src/lib/settings-content.js';
+import { PEOPLE } from '../src/lib/people-content.js';
 import {
   ROOT, SITE, REPO, TIMEZONE, UTC_OFFSET,
-  loadEntries, loadMessages, sourceOf, contactOf, whoIs, createResolver,
+  loadEntries, loadMessages, sourceOf, contactOf, whoIs, createResolver, mentionsOf, createLocator, isPaged, PREVIEW_MESSAGES,
   urlsIn, linksToMarkdown, linksToText, linksToHtml, escapeHtml,
-  longDate, phonePretty, messageText,
+  longDate, phonePretty, messageText, citationOf, messageUrl,
 } from './lib/corpus.mjs';
 
 const DIST = join(ROOT, 'dist');
@@ -38,9 +47,25 @@ const template = readFileSync(templatePath, 'utf-8');
 const today = new Date().toISOString().slice(0, 10);
 const entries = loadEntries();
 const resolve = createResolver(entries);
+const byId = new Map(entries.map(e => [e.id, e]));
 
-/** Martha's 65k would make a page nobody should have to download. */
-const PREVIEW_MESSAGES = 200;
+const monthFmt = new Intl.DateTimeFormat('pt-BR', { month: 'long', year: 'numeric' });
+const longMonth = (ym) => monthFmt.format(new Date(`${ym}-15T12:00:00`));
+
+/** 'YYYY-MM' → messages of that month, in order. */
+function monthsOf(messages) {
+  const months = new Map();
+  for (const msg of messages) {
+    const ym = msg.date.slice(0, 7);
+    if (!months.has(ym)) months.set(ym, []);
+    months.get(ym).push(msg);
+  }
+  return months;
+}
+
+const locate = createLocator(entries);
+/** The static page (no fragment) where a message's anchor lives. */
+const pathOf = (conversationId, msg) => locate(conversationId, msg)?.replace(/#.*$/, '') ?? null;
 
 function reportDoc(source) {
   const doc = {
@@ -57,114 +82,25 @@ function reportDoc(source) {
   return doc;
 }
 
-// ── per-conversation page ──────────────────────────────────────────────────
+// ── page skeleton ──────────────────────────────────────────────────────────
 
-/** A description a search result can show, from the profile when there is one. */
-function describe(entry, profile, who) {
-  const first = profile?.sections?.[0]?.paragraphs?.[0]?.text;
-  const fallback = `Conversa entre Daniel Vorcaro e ${who}: ${entry.total_messages} mensagens, de ${entry.date_range.start} a ${entry.date_range.end}, no MasterWhats.`;
-  if (!first) return fallback;
-  const text = linksToText(first).replace(/\s+/g, ' ').trim();
-  if (text.length <= 155) return text;
-  return `${text.slice(0, 155).replace(/\s+\S*$/, '')}…`;
-}
-
-function jsonLd(entry, who, description) {
-  const url = `${SITE}/chat/${entry.id}`;
-  const source = sourceOf(entry);
-  const data = {
-    '@context': 'https://schema.org',
-    '@type': 'Conversation',
-    '@id': url,
-    name: `Daniel Vorcaro ↔ ${who}`,
-    url,
-    inLanguage: 'pt-BR',
-    description,
-    temporalCoverage: `${entry.date_range.start}/${entry.date_range.end}`,
-    about: [
-      { '@type': 'Person', name: 'Daniel Vorcaro' },
-      { '@type': 'Person', name: who },
-    ],
-    isPartOf: { '@id': `${SITE}/#dataset` },
-    encoding: [
-      { '@type': 'MediaObject', encodingFormat: 'text/markdown', contentUrl: `${SITE}/export/masterwhats-${entry.id}.md` },
-      { '@type': 'MediaObject', encodingFormat: 'application/json', contentUrl: `${SITE}/export/masterwhats-${entry.id}.json` },
-    ],
-    dateModified: today,
-  };
-  if (source.kind === 'police-report') data.isBasedOn = reportDoc(source);
-  return JSON.stringify(data, null, 2);
-}
-
-function article(entry, messages, profile, who) {
-  const source = sourceOf(entry);
-  const shown = messages.slice(0, PREVIEW_MESSAGES);
-  const out = [];
-
-  out.push(`<article id="prerender">`);
-  out.push(`<h1>Daniel Vorcaro ↔ ${escapeHtml(who)}</h1>`);
-  out.push(`<p>${entry.total_messages} mensagens, de ${entry.date_range.start} a ${entry.date_range.end}. `
-    + `<a href="/#/chat/${entry.id}">Abrir no MasterWhats</a> · `
-    + `<a href="/export/masterwhats-${entry.id}.md">Markdown completo</a> · `
-    + `<a href="/export/masterwhats-${entry.id}.json">JSON</a></p>`);
-
-  out.push('<h2>Proveniência</h2><dl>');
-  out.push(`<dt>Fonte</dt><dd>${escapeHtml(source.label)}</dd>`);
-  if (source.document) out.push(`<dt>Documento</dt><dd>${source.document_url ? `<a href="${escapeHtml(source.document_url)}" rel="noopener">${escapeHtml(source.document)}</a>` : escapeHtml(source.document)}${source.document_pages ? `, ${source.document_pages} páginas` : ''} (no repositório; o site não serve o PDF)</dd>`);
-  if (source.document_sha256) out.push(`<dt>sha256 do documento</dt><dd><code>${source.document_sha256}</code></dd>`);
-  out.push(`<dt>Como chegou ao público</dt><dd>${escapeHtml(source.how)}</dd>`);
-  if (entry.saved_as) out.push(`<dt>Contato salvo como</dt><dd>${escapeHtml(entry.saved_as)}</dd>`);
-  if (entry.phone) out.push(`<dt>Telefone</dt><dd>${escapeHtml(phonePretty(entry.phone))}</dd>`);
-  out.push(`<dt>Fuso dos horários</dt><dd>${TIMEZONE} (UTC${UTC_OFFSET})</dd>`);
-  if (entry.note) out.push(`<dt>Observação</dt><dd>${escapeHtml(entry.note)}</dd>`);
-  out.push('</dl>');
-
-  const urls = [];
-  if (profile) {
-    out.push(`<h2>Quem é ${escapeHtml(who)}</h2>`);
-    for (const section of profile.sections || []) {
-      if (section.title && section.title !== who && section.title !== `Sobre ${who}`) {
-        out.push(`<h3>${escapeHtml(section.title)}</h3>`);
-      }
-      for (const p of section.paragraphs || []) {
-        urls.push(...urlsIn(p.text));
-        out.push(`<p>${linksToHtml(p.text, { resolve, context: entry.id, samePage: entry.id })}</p>`);
-      }
-    }
-  }
-
-  out.push(`<h2>Conversa${shown.length < messages.length ? ` (primeiras ${shown.length} mensagens)` : ''}</h2>`);
-  let day = null;
-  for (const msg of shown) {
-    if (msg.date !== day) {
-      day = msg.date;
-      out.push(`<h3>${longDate(day)}</h3>`);
-    }
-    const cite = msg.source_page ? ` <small>(laudo p. ${msg.source_page}${msg.source_figure ? `, fig. ${msg.source_figure}` : ''})</small>` : '';
-    out.push(`<p id="msg-${msg.id}"><time datetime="${msg.timestamp}${UTC_OFFSET}">${msg.time.slice(0, 5)}</time> <b>${escapeHtml(msg.sender)}</b>: ${escapeHtml(messageText(msg))}${cite}</p>`);
-  }
-  if (shown.length < messages.length) {
-    out.push(`<p>As outras ${messages.length - shown.length} mensagens estão no <a href="/export/masterwhats-${entry.id}.md">Markdown completo</a> e <a href="/#/chat/${entry.id}">no app</a>.</p>`);
-  }
-
-  const sources = [...new Set(urls)];
-  if (sources.length) {
-    out.push('<h2>Fontes</h2><ul>');
-    for (const u of sources) out.push(`<li><a href="${escapeHtml(u)}" rel="noopener">${escapeHtml(u)}</a></li>`);
-    out.push('</ul>');
-  }
-  out.push('</article>');
-  return out.join('\n');
-}
-
-function page(entry, messages) {
-  const profile = getContactProfile(entry.id);
-  const who = whoIs(entry, profile);
-  const title = `Daniel Vorcaro ↔ ${who} — MasterWhats`;
-  const description = describe(entry, profile, who);
-  const url = `${SITE}/chat/${entry.id}`;
-  const attr = (s) => escapeHtml(s);
-
+/**
+ * The built app page, retitled and with an article in it.
+ *
+ * @param {object} o
+ * @param {string} o.title
+ * @param {string} o.description
+ * @param {string} o.path - canonical path, e.g. /chat/x
+ * @param {object} o.jsonLd
+ * @param {string} o.chat - the conversation the app opens; a #msg-N fragment
+ *   on the way in becomes that message in the app
+ * @param {string} o.hash - what the app opens when there is no fragment
+ * @param {string} o.article - the HTML for crawlers
+ * @param {string} [o.extraHead]
+ */
+function appPage({ title, description, path, jsonLd, chat, hash, article, extraHead = '' }) {
+  const url = `${SITE}${path}`;
+  const attr = escapeHtml;
   let html = template;
   const swap = (re, replacement) => {
     if (!re.test(html)) throw new Error(`template lost ${re}`);
@@ -181,11 +117,281 @@ function page(entry, messages) {
 
   // The home page's structured data does not describe this page.
   html = html.replace(/\s*<script type="application\/ld\+json">[\s\S]*?<\/script>/g, '');
-  swap(/<\/head>/, `<script type="application/ld+json">\n${jsonLd(entry, who, description)}\n</script>\n`
-    + `<script>if(!location.hash)location.replace('#/chat/${entry.id}')</script>\n</head>`);
+  swap(/<\/head>/, `<script type="application/ld+json">\n${JSON.stringify(jsonLd, null, 2)}\n</script>\n`
+    + extraHead
+    // A crawler follows #msg-N to the anchor; a browser gets the app at that message.
+    + `<script>(function(){var m=location.hash.match(/^#msg-(\\d+)$/);if(m)location.replace('#/chat/${chat}/msg/'+m[1]);else if(!location.hash)location.replace('${hash}')})()</script>\n</head>`);
 
-  swap(/\s*<noscript>/, `\n${article(entry, messages, profile, who)}\n<noscript>`);
+  swap(/\s*<noscript>/, `\n${article}\n<noscript>`);
   return html;
+}
+
+// ── conversation pages ─────────────────────────────────────────────────────
+
+/** A description a search result can show, from the profile when there is one. */
+function describe(entry, profile, who) {
+  const first = profile?.sections?.[0]?.paragraphs?.[0]?.text;
+  const fallback = `Conversa entre Daniel Vorcaro e ${who}: ${entry.total_messages} mensagens, de ${entry.date_range.start} a ${entry.date_range.end}, no MasterWhats.`;
+  if (!first) return fallback;
+  const text = linksToText(first).replace(/\s+/g, ' ').trim();
+  if (text.length <= 155) return text;
+  return `${text.slice(0, 155).replace(/\s+\S*$/, '')}…`;
+}
+
+function conversationLd(entry, who, description, { path, month, first, last, parent } = {}) {
+  const url = `${SITE}${path}`;
+  const source = sourceOf(entry);
+  const data = {
+    '@context': 'https://schema.org',
+    '@type': 'Conversation',
+    '@id': url,
+    name: month ? `Daniel Vorcaro ↔ ${who} — ${longMonth(month)}` : `Daniel Vorcaro ↔ ${who}`,
+    url,
+    inLanguage: 'pt-BR',
+    description,
+    temporalCoverage: `${first}/${last}`,
+    about: [
+      { '@type': 'Person', name: 'Daniel Vorcaro' },
+      { '@type': 'Person', name: who },
+    ],
+    isPartOf: parent ? { '@id': `${SITE}${parent}` } : { '@id': `${SITE}/#dataset` },
+    encoding: [
+      { '@type': 'MediaObject', encodingFormat: 'text/markdown', contentUrl: `${SITE}/export/masterwhats-${entry.id}.md` },
+      { '@type': 'MediaObject', encodingFormat: 'application/json', contentUrl: `${SITE}/export/masterwhats-${entry.id}.json` },
+    ],
+    dateModified: today,
+  };
+  if (source.kind === 'police-report') data.isBasedOn = reportDoc(source);
+  return data;
+}
+
+function messagesHtml(messages) {
+  const out = [];
+  let day = null;
+  for (const msg of messages) {
+    if (msg.date !== day) {
+      day = msg.date;
+      out.push(`<h3>${longDate(day)}</h3>`);
+    }
+    const cite = msg.source_page ? ` <small>(laudo p. ${msg.source_page}${msg.source_figure ? `, fig. ${msg.source_figure}` : ''})</small>` : '';
+    out.push(`<p id="msg-${msg.id}"><time datetime="${msg.timestamp}${UTC_OFFSET}">${msg.time.slice(0, 5)}</time> <b>${escapeHtml(msg.sender)}</b>: ${escapeHtml(messageText(msg))}${cite}</p>`);
+  }
+  return out;
+}
+
+function provenanceHtml(entry) {
+  const source = sourceOf(entry);
+  const out = ['<h2>Proveniência</h2><dl>'];
+  out.push(`<dt>Fonte</dt><dd>${escapeHtml(source.label)}</dd>`);
+  if (source.document) out.push(`<dt>Documento</dt><dd>${source.document_url ? `<a href="${escapeHtml(source.document_url)}" rel="noopener">${escapeHtml(source.document)}</a>` : escapeHtml(source.document)}${source.document_pages ? `, ${source.document_pages} páginas` : ''} (no repositório; o site não serve o PDF)</dd>`);
+  if (source.document_sha256) out.push(`<dt>sha256 do documento</dt><dd><code>${source.document_sha256}</code></dd>`);
+  out.push(`<dt>Como chegou ao público</dt><dd>${escapeHtml(source.how)}</dd>`);
+  if (entry.saved_as) out.push(`<dt>Contato salvo como</dt><dd>${escapeHtml(entry.saved_as)}</dd>`);
+  if (entry.phone) out.push(`<dt>Telefone</dt><dd>${escapeHtml(phonePretty(entry.phone))}</dd>`);
+  out.push(`<dt>Fuso dos horários</dt><dd>${TIMEZONE} (UTC${UTC_OFFSET})</dd>`);
+  if (entry.note) out.push(`<dt>Observação</dt><dd>${escapeHtml(entry.note)}</dd>`);
+  out.push('</dl>');
+  return out;
+}
+
+function profileHtml(profile, who, entry, fromPath) {
+  const out = [];
+  const urls = [];
+  if (!profile) return { html: out, urls };
+  out.push(`<h2>Quem é ${escapeHtml(who)}</h2>`);
+  for (const section of profile.sections || []) {
+    if (section.title && section.title !== who && section.title !== `Sobre ${who}`) {
+      out.push(`<h3>${escapeHtml(section.title)}</h3>`);
+    }
+    for (const p of section.paragraphs || []) {
+      urls.push(...urlsIn(p.text));
+      out.push(`<p>${linksToHtml(p.text, { resolve, context: entry.id, hrefFor: locate, fromPath })}</p>`);
+    }
+  }
+  return { html: out, urls };
+}
+
+function sourcesHtml(urls) {
+  const sources = [...new Set(urls)];
+  if (!sources.length) return [];
+  return ['<h2>Fontes</h2><ul>', ...sources.map(u => `<li><a href="${escapeHtml(u)}" rel="noopener">${escapeHtml(u)}</a></li>`), '</ul>'];
+}
+
+function conversationPage(entry, messages, profile, who) {
+  const path = `/chat/${entry.id}`;
+  const months = monthsOf(messages);
+  const paged = isPaged(entry);
+  const shown = paged ? messages.slice(0, PREVIEW_MESSAGES) : messages;
+  const out = [];
+
+  out.push(`<article id="prerender">`);
+  out.push(`<h1>Daniel Vorcaro ↔ ${escapeHtml(who)}</h1>`);
+  out.push(`<p>${entry.total_messages} mensagens, de ${entry.date_range.start} a ${entry.date_range.end}. `
+    + `<a href="/#/chat/${entry.id}">Abrir no MasterWhats</a> · `
+    + `<a href="/export/masterwhats-${entry.id}.md">Markdown completo</a> · `
+    + `<a href="/export/masterwhats-${entry.id}.json">JSON</a></p>`);
+  out.push(...provenanceHtml(entry));
+  const { html: profileBlock, urls } = profileHtml(profile, who, entry, path);
+  out.push(...profileBlock);
+
+  if (paged) {
+    out.push(`<h2>Meses</h2><p>A conversa inteira, um mês por página:</p><ul>`);
+    for (const [ym, msgs] of months) {
+      out.push(`<li><a href="${path}/${ym}">${longMonth(ym)}</a> — ${msgs.length} mensagens</li>`);
+    }
+    out.push('</ul>');
+  }
+
+  out.push(`<h2>Conversa${paged ? ` (primeiras ${shown.length} mensagens)` : ''}</h2>`);
+  out.push(...messagesHtml(shown));
+  if (paged) {
+    out.push(`<p>As outras ${messages.length - shown.length} mensagens estão nas páginas por mês acima, no <a href="/export/masterwhats-${entry.id}.md">Markdown completo</a> e <a href="/#/chat/${entry.id}">no app</a>.</p>`);
+  }
+  out.push(...sourcesHtml(urls));
+  out.push('</article>');
+
+  const description = describe(entry, profile, who);
+  return appPage({
+    title: `Daniel Vorcaro ↔ ${who} — MasterWhats`,
+    description,
+    path,
+    jsonLd: conversationLd(entry, who, description, { path, first: entry.date_range.start, last: entry.date_range.end }),
+    chat: entry.id,
+    hash: `#/chat/${entry.id}`,
+    article: out.join('\n'),
+  });
+}
+
+function monthPage(entry, who, ym, msgs, prevYm, nextYm) {
+  const path = `/chat/${entry.id}/${ym}`;
+  const parent = `/chat/${entry.id}`;
+  const out = [];
+  out.push(`<article id="prerender">`);
+  out.push(`<h1>Daniel Vorcaro ↔ ${escapeHtml(who)} — ${longMonth(ym)}</h1>`);
+  out.push(`<p>${msgs.length} mensagens em ${longMonth(ym)}, de ${msgs[0].date} a ${msgs.at(-1).date}. `
+    + `<a href="${parent}">A conversa</a> · `
+    + (prevYm ? `<a href="${parent}/${prevYm}" rel="prev">${longMonth(prevYm)}</a> · ` : '')
+    + (nextYm ? `<a href="${parent}/${nextYm}" rel="next">${longMonth(nextYm)}</a> · ` : '')
+    + `<a href="/#/chat/${entry.id}/msg/${msgs[0].id}">Abrir no MasterWhats</a> · `
+    + `<a href="/export/masterwhats-${entry.id}.md">Markdown completo</a></p>`);
+  out.push(...messagesHtml(msgs));
+  out.push('</article>');
+
+  const description = `Conversa entre Daniel Vorcaro e ${who} em ${longMonth(ym)}: ${msgs.length} mensagens, de ${msgs[0].date} a ${msgs.at(-1).date}.`;
+  const links = (prevYm ? `<link rel="prev" href="${SITE}${parent}/${prevYm}">\n` : '')
+    + (nextYm ? `<link rel="next" href="${SITE}${parent}/${nextYm}">\n` : '');
+  return appPage({
+    title: `Daniel Vorcaro ↔ ${who} — ${longMonth(ym)} — MasterWhats`,
+    description,
+    path,
+    jsonLd: conversationLd(entry, who, description, { path, month: ym, first: msgs[0].date, last: msgs.at(-1).date, parent }),
+    chat: entry.id,
+    hash: `#/chat/${entry.id}/msg/${msgs[0].id}`,
+    article: out.join('\n'),
+    extraHead: links,
+  });
+}
+
+// ── people ─────────────────────────────────────────────────────────────────
+
+/** A page of its own: the app has no route for it, so it does not boot the app. */
+function standalone({ title, description, path, jsonLd, body }) {
+  const url = `${SITE}${path}`;
+  return `<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>${escapeHtml(title)}</title>
+<meta name="description" content="${escapeHtml(description)}">
+<link rel="canonical" href="${url}">
+<meta property="og:title" content="${escapeHtml(title)}">
+<meta property="og:description" content="${escapeHtml(description)}">
+<meta property="og:url" content="${url}">
+<meta property="og:type" content="website">
+<meta property="og:image" content="${SITE}/assets/og-image.png">
+<link rel="icon" href="/favicon.ico" sizes="any">
+<link rel="alternate" type="text/plain" href="/llms.txt" title="llms.txt">
+<script type="application/ld+json">
+${JSON.stringify(jsonLd, null, 2)}
+</script>
+<style>
+  body { margin: 0; background: #f0f2f5; color: #111b21; font: 16px/1.5 Roboto, "Helvetica Neue", Arial, sans-serif; }
+  main { max-width: 760px; margin: 0 auto; padding: 24px 20px 48px; }
+  header { border-bottom: 1px solid #d1d7db; padding-bottom: 12px; margin-bottom: 20px; }
+  header a { color: #1daa61; text-decoration: none; font-weight: 700; }
+  h1 { font-size: 1.6rem; margin: 8px 0 4px; }
+  h2 { font-size: 1.15rem; margin: 28px 0 8px; }
+  p { margin: 8px 0; }
+  .role, small, .how { color: #667781; }
+  .msg { background: #fff; border-radius: 8px; padding: 10px 12px; margin: 8px 0; }
+  .msg time { color: #667781; font-size: .9rem; }
+  .msg .links { font-size: .85rem; }
+  a { color: #027eb5; }
+  ul.people li { margin: 6px 0; }
+</style>
+</head>
+<body>
+<main>
+<header><a href="/">MasterWhats</a> · <a href="/quem/">Pessoas citadas</a></header>
+${body}
+</main>
+</body>
+</html>
+`;
+}
+
+function mentionHtml(conversationId, msg) {
+  const cite = msg.source_page ? ` <small>(laudo p. ${msg.source_page}${msg.source_figure ? `, fig. ${msg.source_figure}` : ''})</small>` : '';
+  return `<div class="msg" id="m-${conversationId}-${msg.id}">`
+    + `<time datetime="${msg.timestamp}${UTC_OFFSET}">${citationOf(msg).split(' · ')[0]}</time> · <b>${escapeHtml(msg.sender)}</b>${cite}<br>`
+    + `${escapeHtml(messageText(msg))}<br>`
+    + `<span class="links"><a href="${locate(conversationId, msg)}">ver na conversa</a> · <a href="${messageUrl(conversationId, msg)}">no app</a> · msg ${msg.id}</span>`
+    + `</div>`;
+}
+
+function personPage(person, mentions) {
+  const path = `/quem/${person.slug}`;
+  const total = [...mentions.values()].reduce((n, v) => n + v.length, 0);
+  const convs = [...mentions.keys()].map(id => byId.get(id));
+  const description = `${person.name}, ${person.role}: ${total} menções em ${convs.length} conversa${convs.length === 1 ? '' : 's'} dos celulares de Daniel Vorcaro — ${convs.map(contactOf).join(', ')}.`;
+  const body = [];
+  body.push(`<h1>${escapeHtml(person.name)}</h1>`);
+  body.push(`<p class="role">${escapeHtml(person.role)}${person.profile ? ` · <a href="/chat/${person.profile}">perfil e conversa com Vorcaro</a>` : ''}</p>`);
+  body.push(`<p>${total} menções em ${convs.length} conversa${convs.length === 1 ? '' : 's'}. Cada uma linka a mensagem na conversa e no app; as do relatório da PF citam página e figura do laudo.</p>`);
+  body.push(`<p class="how">Como as mensagens se referem a essa pessoa: ${person.aliases.map(a => `<code>${escapeHtml(a.match)}</code>${a.only ? ` (só em ${a.only.map(id => contactOf(byId.get(id))).join(', ')})` : ''}`).join(', ')}.</p>`);
+  for (const [id, msgs] of mentions) {
+    const entry = byId.get(id);
+    body.push(`<h2><a href="/chat/${id}">Daniel Vorcaro ↔ ${escapeHtml(contactOf(entry))}</a> — ${msgs.length} men${msgs.length === 1 ? 'ção' : 'ções'}</h2>`);
+    for (const msg of msgs) body.push(mentionHtml(id, msg));
+  }
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'WebPage',
+    '@id': `${SITE}${path}`,
+    url: `${SITE}${path}`,
+    name: `${person.name} nas conversas de Daniel Vorcaro`,
+    description,
+    inLanguage: 'pt-BR',
+    about: { '@type': 'Person', name: person.name, jobTitle: person.role },
+    isPartOf: { '@id': `${SITE}/#dataset` },
+    dateModified: today,
+  };
+  return standalone({ title: `${person.name} nas conversas de Daniel Vorcaro — MasterWhats`, description, path, jsonLd, body: body.join('\n') });
+}
+
+function peopleIndex(people) {
+  const body = ['<h1>Pessoas citadas</h1>', '<p>Quem aparece nas conversas de Daniel Vorcaro, com toda menção datada e apontando para a mensagem.</p>', '<ul class="people">'];
+  for (const { person, mentions } of people) {
+    const total = [...mentions.values()].reduce((n, v) => n + v.length, 0);
+    body.push(`<li><a href="/quem/${person.slug}">${escapeHtml(person.name)}</a> — ${escapeHtml(person.role)} · ${total} menções em ${mentions.size} conversa${mentions.size === 1 ? '' : 's'}</li>`);
+  }
+  body.push('</ul>');
+  const jsonLd = {
+    '@context': 'https://schema.org', '@type': 'CollectionPage', '@id': `${SITE}/quem/`, url: `${SITE}/quem/`,
+    name: 'Pessoas citadas nas conversas de Daniel Vorcaro', inLanguage: 'pt-BR', isPartOf: { '@id': `${SITE}/#dataset` }, dateModified: today,
+  };
+  return standalone({ title: 'Pessoas citadas — MasterWhats', description: 'Quem aparece nas conversas de Daniel Vorcaro, com toda menção datada e apontando para a mensagem.', path: '/quem/', jsonLd, body: body.join('\n') });
 }
 
 // ── llms-full.txt ──────────────────────────────────────────────────────────
@@ -194,28 +400,29 @@ function profileParagraphs(profile, context) {
   const out = [];
   for (const section of profile?.sections || []) {
     if (section.title) out.push(`**${section.title}**`, '');
-    for (const p of section.paragraphs || []) out.push(linksToMarkdown(p.text, { resolve, context }), '');
+    for (const p of section.paragraphs || []) out.push(linksToMarkdown(p.text, { resolve, context, hrefFor: locate }), '');
   }
   return out;
 }
 
-function llmsFull(built) {
+function llmsFull(built, people) {
   const total = built.reduce((n, b) => n + b.entry.total_messages, 0);
   const about = SETTINGS_CONTENT.sections.find(s => s.title === 'Sobre o Projeto');
   const rest = SETTINGS_CONTENT.sections.filter(s => s !== about);
   const out = [
     '# MasterWhats — conteúdo completo', '',
-    `> Tudo que o site diz, em texto. Cada citação traz ⟨data hora · laudo p., fig.⟩ e linka a mensagem: o link do app é ${SITE}/#/chat/<id>/msg/<n>, e o mesmo n aparece como "msg n" no Markdown de cada conversa. ${built.length} conversas, ${total} mensagens, de ${built.at(-1)?.entry.date_range.start ?? ''} a ${built[0]?.entry.date_range.end ?? ''}. Gerado em ${today}. Código e dados: ${REPO}.`, '',
+    `> Tudo que o site diz, em texto. Cada citação traz ⟨data hora · laudo p., fig.⟩ e linka a mensagem na página estática (${SITE}/chat/<id>#msg-<n>, ou a página do mês na conversa com Martha Graeff); a mesma página abre o app nessa mensagem para quem tem JavaScript. O mesmo n aparece como "msg n" no Markdown de cada conversa. ${built.length} conversas, ${total} mensagens, de ${built.at(-1)?.entry.date_range.start ?? ''} a ${built[0]?.entry.date_range.end ?? ''}. Gerado em ${today}. Código e dados: ${REPO}.`, '',
     '## Sobre o projeto', '',
-    ...(about?.paragraphs || []).map(p => linksToMarkdown(p.text, { resolve }) + '\n'),
+    ...(about?.paragraphs || []).map(p => linksToMarkdown(p.text, { resolve, hrefFor: locate }) + '\n'),
     '## Quem é Daniel Vorcaro', '',
     ...profileParagraphs(VORCARO_PROFILE, 'martha-graeff'),
     `## Conversas (${built.length})`, '',
   ];
-  for (const { entry, who, profile } of built) {
+  for (const { entry, who, profile, months } of built) {
     const source = sourceOf(entry);
     out.push(`### ${who} — ${entry.total_messages} mensagens, ${entry.date_range.start} a ${entry.date_range.end}`, '');
     out.push(`- Página: ${SITE}/chat/${entry.id}`);
+    if (months) out.push(`- Um mês por página: ${[...months.keys()].map(ym => `${SITE}/chat/${entry.id}/${ym}`).join(' · ')}`);
     out.push(`- Conversa completa em Markdown: ${SITE}/export/masterwhats-${entry.id}.md · JSON: ${SITE}/export/masterwhats-${entry.id}.json`);
     out.push(`- Fonte: ${source.label}`);
     if (entry.saved_as) out.push(`- Salvo no celular como: ${entry.saved_as}`);
@@ -223,9 +430,22 @@ function llmsFull(built) {
     out.push('');
     out.push(...profileParagraphs(profile, entry.id));
   }
+  out.push(`## Pessoas citadas (${people.length})`, '', `Índice em ${SITE}/quem/ — cada página lista toda menção, por conversa, datada e apontando para a mensagem.`, '');
+  for (const { person, mentions } of people) {
+    const per = [...mentions].map(([id, msgs]) => `${contactOf(byId.get(id))} (${msgs.length})`).join(', ');
+    out.push(`- [${person.name}](${SITE}/quem/${person.slug}) — ${person.role}. Citado em: ${per}.`);
+  }
+  out.push('');
   for (const section of rest) {
     out.push(`## ${section.title}`, '');
-    for (const p of section.paragraphs) out.push(linksToMarkdown(p.text, { resolve }), '');
+    for (const p of section.paragraphs) out.push(linksToMarkdown(p.text, { resolve, hrefFor: locate }), '');
+  }
+  const report = entries.map(e => e.source_document).find(Boolean);
+  if (report) {
+    out.push('## Documento-fonte do relatório da PF', '',
+      `- Arquivo: ${report.file} — ${report.pages} páginas`,
+      `- sha256: ${report.sha256}`,
+      `- Onde obter: ${report.url} (o site não serve o PDF; o caminho acima é do repositório)`, '');
   }
   out.push('## Fontes gerais', '', ...SOURCES.map(s => `- [${s.label}](${s.url})`), '');
   out.push('## Export', '',
@@ -238,14 +458,17 @@ function llmsFull(built) {
 
 // ── sitemap ────────────────────────────────────────────────────────────────
 
-function sitemap(built) {
+function sitemap(built, people) {
   const url = (loc, priority, changefreq = 'weekly') =>
     `  <url>\n    <loc>${loc}</loc>\n    <lastmod>${today}</lastmod>\n    <changefreq>${changefreq}</changefreq>\n    <priority>${priority}</priority>\n  </url>`;
   const rows = [url(`${SITE}/`, '1.0')];
-  for (const { entry } of built) {
+  for (const { entry, months } of built) {
     const headline = entry.id === 'alexandre-de-moraes' || entry.id === 'martha-graeff';
     rows.push(url(`${SITE}/chat/${entry.id}`, headline ? '0.9' : '0.8'));
+    if (months) for (const ym of months.keys()) rows.push(url(`${SITE}/chat/${entry.id}/${ym}`, '0.6', 'monthly'));
   }
+  rows.push(url(`${SITE}/quem/`, '0.8'));
+  for (const { person } of people) rows.push(url(`${SITE}/quem/${person.slug}`, '0.7'));
   rows.push(url(`${SITE}/llms.txt`, '0.7'));
   rows.push(url(`${SITE}/llms-full.txt`, '0.7'));
   rows.push(url(`${SITE}/export/masterwhats.md`, '0.6', 'monthly'));
@@ -257,21 +480,47 @@ function sitemap(built) {
 
 const built = [];
 for (const entry of entries) {
-  const messages = loadMessages(entry);
+  const messages = resolve.messagesOf(entry.id);
   const profile = getContactProfile(entry.id);
   const who = whoIs(entry, profile);
   const dir = join(DIST, 'chat', entry.id);
   mkdirSync(dir, { recursive: true });
-  writeFileSync(join(dir, 'index.html'), page(entry, messages));
-  built.push({ entry, who, profile });
-  console.log(`chat/${entry.id}/ — ${who}`);
+  writeFileSync(join(dir, 'index.html'), conversationPage(entry, messages, profile, who));
+
+  let months = null;
+  if (isPaged(entry)) {
+    months = monthsOf(messages);
+    const yms = [...months.keys()];
+    yms.forEach((ym, i) => {
+      mkdirSync(join(dir, ym), { recursive: true });
+      writeFileSync(join(dir, ym, 'index.html'), monthPage(entry, who, ym, months.get(ym), yms[i - 1], yms[i + 1]));
+    });
+  }
+  built.push({ entry, who, profile, months });
+  console.log(`chat/${entry.id}/ — ${who}${months ? ` (${months.size} meses)` : ''}`);
 }
+
+const people = [];
+for (const person of PEOPLE) {
+  const mentions = mentionsOf(person, entries, resolve.messagesOf);
+  if (!mentions.size) {
+    console.error(`pessoa sem menção nenhuma: ${person.slug} — confira os apelidos em people-content.js`);
+    process.exit(1);
+  }
+  const dir = join(DIST, 'quem', person.slug);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'index.html'), personPage(person, mentions));
+  people.push({ person, mentions });
+  console.log(`quem/${person.slug}/ — ${[...mentions.values()].reduce((n, v) => n + v.length, 0)} menções`);
+}
+writeFileSync(join(DIST, 'quem', 'index.html'), peopleIndex(people));
+
 // The sizes the index quotes decide whether a crawler downloads a file. They
 // are stamped from the files themselves rather than typed and forgotten.
 const mb = (name) => `${(statSync(join(DIST, 'export', name)).size / 1048576).toFixed(1)} MB`;
 const SIZES = { 'masterwhats.md': mb('masterwhats.md'), 'masterwhats.json': mb('masterwhats.json'), 'masterwhats-export.zip': mb('masterwhats-export.zip') };
 const stampSizes = (text) => text.replace(/(masterwhats(?:-export)?\.(?:md|json|zip)) \([\d.,]+ MB\)/g, (m, name) => `${name} (${SIZES[name] || m.slice(name.length + 2, -1)})`);
 writeFileSync(join(DIST, 'llms.txt'), stampSizes(readFileSync(join(DIST, 'llms.txt'), 'utf-8')));
-writeFileSync(join(DIST, 'llms-full.txt'), stampSizes(llmsFull(built)));
-writeFileSync(join(DIST, 'sitemap.xml'), sitemap(built));
-console.log(`\nDone! ${built.length} pages, llms-full.txt, sitemap.xml → ${DIST}`);
+writeFileSync(join(DIST, 'llms-full.txt'), stampSizes(llmsFull(built, people)));
+writeFileSync(join(DIST, 'sitemap.xml'), sitemap(built, people));
+console.log(`\nDone! ${built.length} conversations, ${people.length} people, llms-full.txt, sitemap.xml → ${DIST}`);

--- a/src/lib/people-content.js
+++ b/src/lib/people-content.js
@@ -1,0 +1,87 @@
+/**
+ * People who are talked about in the conversations, for the "Quem" index.
+ *
+ * Each entry names a person once and lists how the messages refer to them. The
+ * build scans every conversation for those aliases and gives the person a
+ * page — /quem/<slug> — with every mention grouped by conversation, dated and
+ * pointing at the message. A person is only as findable as their aliases.
+ *
+ * Aliases are matched on the app's normalised text (lower case, no accents),
+ * at word boundaries. `only` limits an alias to some conversations — "Paulo"
+ * means Gonet in the chat with Moraes and nobody in particular elsewhere;
+ * `unless` drops a match that is really someone else — "Barci de Moraes" is
+ * the law firm, "Vivi Moraes" is a contact.
+ *
+ * Adding someone: one entry here; the build does the rest and fails if the
+ * person matches nothing.
+ */
+
+export const PEOPLE = [
+  {
+    slug: 'paulo-gonet',
+    name: 'Paulo Gonet',
+    role: 'Procurador-geral da República',
+    aliases: [{ match: 'gonet' }, { match: 'paulo', only: ['alexandre-de-moraes'] }],
+  },
+  {
+    slug: 'alexandre-de-moraes',
+    name: 'Alexandre de Moraes',
+    role: 'Ministro do Supremo Tribunal Federal',
+    profile: 'alexandre-de-moraes',
+    aliases: [{ match: 'moraes', unless: 'barci|vivi' }, { match: 'alexandre', only: ['ana-matos-mkt', 'ciro-soares', 'romy-banco-master'] }],
+  },
+  {
+    slug: 'andre-esteves',
+    name: 'André Esteves',
+    role: 'Sócio-fundador do BTG Pactual',
+    aliases: [{ match: 'esteves' }, { match: 'andre', only: ['martha-graeff'], unless: 'andre (mendonca|fernandes)' }],
+  },
+  {
+    slug: 'gabriel-galipolo',
+    name: 'Gabriel Galípolo',
+    role: 'Presidente do Banco Central',
+    aliases: [{ match: 'galipolo' }],
+  },
+  {
+    slug: 'andrei-rodrigues',
+    name: 'Andrei Rodrigues',
+    role: 'Diretor-geral da Polícia Federal',
+    aliases: [{ match: 'andrei' }],
+  },
+  {
+    slug: 'jair-bolsonaro',
+    name: 'Jair Bolsonaro',
+    role: 'Ex-presidente da República',
+    aliases: [{ match: 'bolsonaro' }],
+  },
+  {
+    slug: 'gilmar-mendes',
+    name: 'Gilmar Mendes',
+    role: 'Ministro do Supremo Tribunal Federal',
+    aliases: [{ match: 'gilmar' }],
+  },
+  {
+    slug: 'dias-toffoli',
+    name: 'Dias Toffoli',
+    role: 'Ministro do Supremo Tribunal Federal',
+    aliases: [{ match: 'toffoli' }],
+  },
+  {
+    slug: 'tarcisio-de-freitas',
+    name: 'Tarcísio de Freitas',
+    role: 'Governador de São Paulo',
+    aliases: [{ match: 'tarcisio' }],
+  },
+  {
+    slug: 'roberto-podval',
+    name: 'Roberto Podval',
+    role: 'Advogado criminalista',
+    aliases: [{ match: 'podval' }],
+  },
+  {
+    slug: 'ciro-nogueira',
+    name: 'Ciro Nogueira',
+    role: 'Senador, ex-ministro da Casa Civil',
+    aliases: [{ match: 'ciro nogueira' }, { match: 'ciro', only: ['martha-graeff'] }],
+  },
+];

--- a/tests/e2e/prerender.test.js
+++ b/tests/e2e/prerender.test.js
@@ -29,3 +29,32 @@ test('a hash already in the URL wins over the page', async ({ page }) => {
   await page.goto('/chat/ciro-soares/#/chat/alexandre-de-moraes');
   await expect(page.locator('.chat-header')).toContainText('Alexandre de Moraes', { timeout: 20000 });
 });
+
+test('a month page reads without JS and opens the app at its first message', async ({ page, request }) => {
+  const res = await request.get('/chat/martha-graeff/2024-12/');
+  expect(res.status()).toBe(200);
+  expect(await res.text()).toContain('<p id="msg-35686">');
+
+  await page.goto('/chat/martha-graeff/2024-12/');
+  await expect(page.locator('.chat-header')).toContainText('Martha Graeff', { timeout: 20000 });
+  expect(await page.evaluate(() => location.hash)).toMatch(/^#\/chat\/martha-graeff\/msg\/\d+$/);
+  await expect(page.locator('#prerender')).toHaveCount(0);
+});
+
+test('a person page stands on its own', async ({ page }) => {
+  await page.goto('/quem/paulo-gonet/');
+  await expect(page.locator('h1')).toHaveText('Paulo Gonet');
+  await expect(page.locator('.msg').first()).toBeVisible();
+  await expect(page.locator('#app')).toHaveCount(0);
+  await expect(page.locator('a[href="/chat/ciro-soares#msg-34"]').first()).toBeVisible();
+});
+
+// A static anchor link, followed by a browser, must land in the app at that
+// message — not at the top of the chat, and not on the list. (Trailing slash
+// for vite's preview server, as above.)
+test('a #msg-N link opens the app at that message', async ({ page }) => {
+  await page.goto('/chat/ciro-soares/#msg-34');
+  await expect(page.locator('.chat-header')).toContainText('Ciro Soares', { timeout: 20000 });
+  await expect.poll(() => page.evaluate(() => location.hash)).toBe('#/chat/ciro-soares/msg/34');
+  await expect(page.locator('#prerender')).toHaveCount(0);
+});

--- a/tests/unit/corpus.test.js
+++ b/tests/unit/corpus.test.js
@@ -7,7 +7,7 @@
 
 import { describe, it, expect } from 'vitest';
 import {
-  createResolver, loadEntries, normalize, citationOf, linksToMarkdown, linksToHtml, linksToText,
+  createResolver, createLocator, loadEntries, normalize, citationOf, linksToMarkdown, linksToHtml, linksToText,
 } from '../../scripts/lib/corpus.mjs';
 
 const entries = loadEntries();
@@ -43,6 +43,16 @@ describe('rendering', () => {
     expect(md).toContain('](https://www.masterwhats.com.br/#/chat/alexandre-de-moraes/msg/39) ⟨15/11/2025 18:22 · laudo p. 109, fig. 108⟩');
     expect(md).toContain('[Ciro](https://www.masterwhats.com.br/chat/ciro-soares)');
     expect(md).toContain('[fonte](https://ex.am/ple)');
+  });
+
+  it('points at the static anchor when told where messages live', () => {
+    const locate = createLocator(entries);
+    expect(linksToMarkdown(text, { ...opts, hrefFor: locate }))
+      .toContain('](https://www.masterwhats.com.br/chat/alexandre-de-moraes#msg-39) ⟨');
+    expect(linksToMarkdown('{x}[action:search@martha-graeff:presidente bacen]', { resolve, hrefFor: locate }))
+      .toContain('](https://www.masterwhats.com.br/chat/martha-graeff/2024-12#msg-35686)');
+    expect(linksToHtml(text, { ...opts, hrefFor: locate, fromPath: '/chat/alexandre-de-moraes' }))
+      .toContain('<a href="#msg-39">');
   });
 
   it('uses an anchor when the message is on the same page', () => {

--- a/tests/unit/export-data.test.js
+++ b/tests/unit/export-data.test.js
@@ -98,7 +98,7 @@ describe('the Markdown', () => {
   // when it was sent and where in the report it is.
   it('turns every highlight into a link with date and page', () => {
     const text = md('alexandre-de-moraes');
-    expect(text).toContain('](https://www.masterwhats.com.br/#/chat/alexandre-de-moraes/msg/');
+    expect(text).toContain('](https://www.masterwhats.com.br/chat/alexandre-de-moraes#msg-');
     expect(text).toMatch(/⟨\d{2}\/\d{2}\/\d{4} \d{2}:\d{2} · laudo p\. \d+, fig\. \d+⟩/);
     expect(text).toContain('218 páginas');
     expect(text).toContain('[no repositório](https://github.com/rafaelbressan/masterzap/blob/main/data/source/');

--- a/tests/unit/prerender.test.js
+++ b/tests/unit/prerender.test.js
@@ -5,7 +5,7 @@
 // `npm run build` comes first.
 
 import { describe, it, expect } from 'vitest';
-import { readFileSync, existsSync, statSync } from 'fs';
+import { readFileSync, existsSync, statSync, readdirSync } from 'fs';
 import { join } from 'path';
 
 const ROOT = join(import.meta.dirname, '../..');
@@ -87,7 +87,7 @@ describe('one page per conversation', () => {
 
   it('opens that chat in the app', () => {
     for (const conv of conversations) {
-      expect(page(conv.id), conv.id).toContain(`if(!location.hash)location.replace('#/chat/${conv.id}')`);
+      expect(page(conv.id), conv.id).toContain(`location.replace('#/chat/${conv.id}')`);
     }
   });
 
@@ -115,6 +115,90 @@ describe('discovery', () => {
     expect(home).toContain('href="/llms-full.txt"');
     const robots = readFileSync(join(ROOT, 'public/robots.txt'), 'utf-8');
     expect(robots).toContain('/llms.txt');
+  });
+});
+
+describe('a conversation too big for one page', () => {
+  const months = readdirSync(join(DIST, 'chat', 'martha-graeff')).filter(n => /^\d{4}-\d{2}$/.test(n)).sort();
+
+  it('gets one page per month, and the main page lists them', () => {
+    expect(months.length).toBeGreaterThan(12);
+    const main = page('martha-graeff');
+    expect(main).toContain('<h2>Meses</h2>');
+    for (const ym of months) expect(main, ym).toContain(`<a href="/chat/martha-graeff/${ym}">`);
+  });
+
+  it('holds only that month, in order, chained to its neighbours', () => {
+    const html = readFileSync(join(DIST, 'chat/martha-graeff/2024-12/index.html'), 'utf-8');
+    expect(html).toContain('<link rel="canonical" href="https://www.masterwhats.com.br/chat/martha-graeff/2024-12">');
+    expect(html).toContain('<link rel="prev" href="https://www.masterwhats.com.br/chat/martha-graeff/2024-11">');
+    expect(html).toContain('<link rel="next" href="https://www.masterwhats.com.br/chat/martha-graeff/2025-01">');
+    const stamps = [...html.matchAll(/<time datetime="(\d{4}-\d{2})-\d{2}T/g)].map(m => m[1]);
+    expect(stamps.length).toBeGreaterThan(100);
+    expect(new Set(stamps)).toEqual(new Set(['2024-12']));
+    const [ld] = ldBlocks(html);
+    expect(ld['@type']).toBe('Conversation');
+    expect(ld.isPartOf['@id']).toBe(`${SITE}/chat/martha-graeff`);
+    expect(html).toContain("location.replace('#/chat/martha-graeff/msg/");
+  });
+
+  // The famous quote lives in December 2024, not among the first 200. Its
+  // anchor is on the month page, and the home page's highlight points there.
+  it('anchors the message on its month page, where the home page points', () => {
+    expect(readFileSync(join(DIST, 'chat/martha-graeff/2024-12/index.html'), 'utf-8')).toContain('<p id="msg-35686">');
+    expect(readFileSync(join(DIST, 'index.html'), 'utf-8')).toContain('href="/chat/martha-graeff/2024-12#msg-35686"');
+  });
+
+  // A static anchor link must work for a browser too: the page opens the app
+  // at that message instead of at the top of the chat.
+  it('turns a #msg-N fragment into the app route for that message', () => {
+    expect(page('alexandre-de-moraes')).toContain("location.replace('#/chat/alexandre-de-moraes/msg/'+m[1])");
+  });
+});
+
+describe('people', () => {
+  const person = (slug) => readFileSync(join(DIST, 'quem', slug, 'index.html'), 'utf-8');
+
+  it('has an index and a page per person', () => {
+    const index = readFileSync(join(DIST, 'quem/index.html'), 'utf-8');
+    expect(index).toContain('<a href="/quem/paulo-gonet">Paulo Gonet</a>');
+    expect(index).toContain('<a href="/quem/andre-esteves">André Esteves</a>');
+  });
+
+  it('lists every mention by conversation, dated, pointing at the message', () => {
+    const html = person('paulo-gonet');
+    expect(html).toContain('<h1>Paulo Gonet</h1>');
+    expect(html).toContain('Daniel Vorcaro ↔ Ciro Soares</a>');
+    expect(html).toContain('Daniel Vorcaro ↔ Ana Matos');
+    expect(html).toContain('href="/chat/ciro-soares#msg-34"');
+    expect(html).toContain('href="https://www.masterwhats.com.br/#/chat/ciro-soares/msg/34"');
+    expect(html).toContain('laudo p. 207, fig. 219');
+    expect(html).toMatch(/<time datetime="2025-03-29T13:58:\d{2}-03:00">29\/03\/2025 13:58<\/time>/);
+  });
+
+  it('says how it read the names, so an ambiguous alias is not a hidden guess', () => {
+    expect(person('paulo-gonet')).toContain('<code>paulo</code> (só em Alexandre de Moraes');
+  });
+
+  it('points a mention in the big conversation at its month page', () => {
+    expect(person('andre-esteves')).toMatch(/href="\/chat\/martha-graeff\/\d{4}-\d{2}#msg-\d+"/);
+  });
+
+  it('describes the page as being about a Person', () => {
+    const [ld] = ldBlocks(person('paulo-gonet'));
+    expect(ld['@type']).toBe('WebPage');
+    expect(ld.about).toEqual({ '@type': 'Person', name: 'Paulo Gonet', jobTitle: 'Procurador-geral da República' });
+  });
+
+  it('is in the sitemap and in llms-full.txt', () => {
+    const xml = readFileSync(join(DIST, 'sitemap.xml'), 'utf-8');
+    expect(xml).toContain(`<loc>${SITE}/quem/</loc>`);
+    expect(xml).toContain(`<loc>${SITE}/quem/paulo-gonet</loc>`);
+    expect(xml).toContain(`<loc>${SITE}/chat/martha-graeff/2024-12</loc>`);
+    const t = readFileSync(join(DIST, 'llms-full.txt'), 'utf-8');
+    expect(t).toContain('## Pessoas citadas (');
+    expect(t).toContain(`[Paulo Gonet](${SITE}/quem/paulo-gonet)`);
+    expect(t).toContain(`${SITE}/chat/martha-graeff/2024-12`);
   });
 });
 
@@ -149,8 +233,10 @@ describe('llms-full.txt', () => {
 
   it('cites every highlight with a link, a date and a page', () => {
     const t = text();
-    expect(t).toContain('/#/chat/alexandre-de-moraes/msg/39) ⟨15/11/2025 18:22 · laudo p. 109, fig. 108⟩');
-    expect(t).toContain('/#/chat/martha-graeff/msg/35686) ⟨04/12/2024 00:33⟩');
+    expect(t).toContain('/chat/alexandre-de-moraes#msg-39) ⟨15/11/2025 18:22 · laudo p. 109, fig. 108⟩');
+    // The famous quote lives in December 2024, on that month's page.
+    expect(t).toContain('/chat/martha-graeff/2024-12#msg-35686) ⟨04/12/2024 00:33⟩');
+    expect(t).toContain('## Documento-fonte do relatório da PF');
   });
 
   it('carries the profiles with their sources as links, and nothing site-only', () => {

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,12 @@
 {
   "trailingSlash": false,
+  "redirects": [
+    {
+      "source": "/data/source/(.*)",
+      "destination": "https://github.com/rafaelbressan/masterzap/blob/main/data/source/$1",
+      "permanent": false
+    }
+  ],
   "rewrites": [
     {
       "source": "/robots.txt",


### PR DESCRIPTION
Closes #14
Closes #15

Quatro testes com agente-crawler apontaram o mesmo par de buracos: qualquer pergunta que cruze conversas custa o corpus inteiro, e a conversa da Martha é opaca sem JavaScript — 200 de 65.772 numa página, e a âncora `#msg-35686` que o site anuncia não existia nela.

## #14 — uma página por mês

Conversa maior que a prévia (200) ganha `dist/chat/<id>/<YYYY-MM>/`: `rel="prev"/"next"`, JSON-LD `Conversation` que é `isPartOf` a conversa, boot do app na primeira mensagem do mês. A página principal lista os meses. A Martha vira **19 páginas**; o "presidente bacen" tem âncora em `/chat/martha-graeff/2024-12#msg-35686`.

## #15 — pessoas citadas

`src/lib/people-content.js` declara quem (nome, papel, apelidos). Apelido ambíguo é explícito: `only` faz "Paulo" valer Gonet só na conversa com Moraes; `unless` impede "Moraes" de pegar o escritório Barci e a contato Vivi. O build escreve `dist/quem/<slug>/` com toda menção por conversa, datada, com página do laudo, apontando pra mensagem na página estática e no app — e **diz na página como leu os apelidos**. Pessoa sem menção nenhuma quebra o build. **11 pessoas**: Gonet (13), Moraes (23), Esteves (39), Galípolo, Andrei Rodrigues, Bolsonaro, Gilmar, Toffoli, Tarcísio, Podval, Ciro Nogueira. Índice em `/quem/`; seção no `llms-full.txt`; sitemap.

A página de pessoa é HTML próprio (o app não tem rota pra ela) com CSS inline — print no chat.

## Citação com âncora estática

O teste 4 apontou: os deep links `/#/chat/<id>/msg/<n>` são fragmento — sem JS caem na raiz. Com página pra toda mensagem, **toda citação** (`.md`, HTML, `llms-full`, `llms.txt`, `noscript` da home) aponta pra âncora estática. O boot da página traduz `#msg-N` em `#/chat/<id>/msg/N`: o mesmo link serve o crawler e abre o app na mensagem pra quem tem JS. Tem teste E2E.

## Restos do teste 4

- `/data/source/*.pdf` no site devolvia 200 HTML → redirect pro GitHub no `vercel.json`
- `llms.txt` e `llms-full.txt` ganham "Documento-fonte": arquivo, 218 páginas, sha256, onde obter

## Testes

217 → 228 unit (meses, pessoas, âncoras, boot); 261 E2E (+3 no preview: página do mês, página de pessoa, `#msg-N` abrindo o app na mensagem).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RPgDUnTk2JuejAso8UHMWb