### PR TITLE
GEO: pessoas por apelido, export por mês, PDF em bytes, /quem canônico

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -45,8 +45,8 @@ Daniel Vorcaro, dono do Banco Master, foi preso pela Polícia Federal em novembr
 
 ## Conteúdo completo em texto
 - https://www.masterwhats.com.br/llms-full.txt — sobre, os 24 perfis com fontes, os destaques, e o link do Markdown de cada conversa
-- Cada conversa tem página própria em https://www.masterwhats.com.br/chat/<id>, em HTML puro: proveniência, perfil com fontes e todas as mensagens com página e figura do laudo. A conversa com Martha Graeff (65 mil mensagens) tem uma página por mês — https://www.masterwhats.com.br/chat/martha-graeff/2024-12 — listadas na página principal
-- Pessoas citadas: https://www.masterwhats.com.br/quem/ — uma página por pessoa (ex.: https://www.masterwhats.com.br/quem/paulo-gonet) com toda menção, por conversa, datada e apontando para a mensagem
+- Cada conversa tem página própria em https://www.masterwhats.com.br/chat/<id>, em HTML puro: proveniência, perfil com fontes e todas as mensagens com página e figura do laudo. A conversa com Martha Graeff (65 mil mensagens) tem uma página por mês — https://www.masterwhats.com.br/chat/martha-graeff/2024-12 — listadas na página principal, e um Markdown por mês: https://www.masterwhats.com.br/export/masterwhats-martha-graeff-2024-12.md
+- Pessoas citadas: https://www.masterwhats.com.br/quem — uma página por pessoa (ex.: https://www.masterwhats.com.br/quem/paulo-gonet) com toda menção, por conversa, datada e apontando para a mensagem
 
 ## Export limpo
 Tudo que o site mostra, em texto, sem o site:
@@ -64,7 +64,7 @@ Cada .md abre com proveniência (fonte, documento com páginas e sha256, períod
 ## Documento-fonte do relatório da PF
 - Arquivo: data/source/IPJ-A-3298613-2026.pdf — 218 páginas
 - sha256: 23cfdfa410c47ab09cbb2b443965e3a3095d9bc3dc5fb266efff76d6f5192b60
-- Onde obter: https://github.com/rafaelbressan/masterzap/blob/main/data/source/IPJ-A-3298613-2026.pdf — o site não serve o PDF; https://www.masterwhats.com.br/data/source/... redireciona para o repositório
+- Onde obter: https://github.com/rafaelbressan/masterzap/blob/main/data/source/IPJ-A-3298613-2026.pdf (página) ou https://raw.githubusercontent.com/rafaelbressan/masterzap/main/data/source/IPJ-A-3298613-2026.pdf (os bytes, 32 MB) — o site não serve o PDF; https://www.masterwhats.com.br/data/source/... redireciona para os bytes
 - Os destaques abaixo e no llms-full.txt já trazem o link e ⟨data hora · laudo p., fig.⟩
 
 ## Fontes

--- a/scripts/export.mjs
+++ b/scripts/export.mjs
@@ -20,7 +20,7 @@ import { getContactProfile, VORCARO_PROFILE, SOURCES } from '../src/lib/profile-
 import { SETTINGS_CONTENT } from '../src/lib/settings-content.js';
 import {
   ROOT, SITE, REPO, TIMEZONE, UTC_OFFSET,
-  loadEntries, loadMessages, sourceOf, contactOf, whoIs, createResolver, createLocator,
+  loadEntries, loadMessages, sourceOf, contactOf, whoIs, createResolver, createLocator, isPaged,
   urlsIn, linksToMarkdown, longDate, phonePretty, MEDIA,
 } from './lib/corpus.mjs';
 
@@ -32,6 +32,8 @@ const entries = loadEntries();
 // Highlights point at messages; resolved once here, for every file below.
 const resolve = createResolver(entries);
 const hrefFor = createLocator(entries);
+const monthFmt = new Intl.DateTimeFormat('pt-BR', { month: 'long', year: 'numeric' });
+const monthName = (ym) => monthFmt.format(new Date(`${ym}-15T12:00:00`));
 const md = (text, context) => linksToMarkdown(text, { resolve, context, hrefFor });
 
 // ── text helpers ───────────────────────────────────────────────────────────
@@ -101,7 +103,7 @@ function profileJson(profile, context) {
 
 // ── one conversation ───────────────────────────────────────────────────────
 
-function conversationMarkdown(entry, messages, { standalone = true } = {}) {
+function conversationMarkdown(entry, messages, { standalone = true, month = null } = {}) {
   const contact = contactOf(entry);
   const source = sourceOf(entry);
   const profile = getContactProfile(entry.id);
@@ -109,17 +111,17 @@ function conversationMarkdown(entry, messages, { standalone = true } = {}) {
   const sub = standalone ? '##' : '###';
   const out = [];
 
-  out.push(`${heading} Daniel Vorcaro ↔ ${contact}`, '');
+  out.push(`${heading} Daniel Vorcaro ↔ ${contact}${month ? ` — ${monthName(month)}` : ''}`, '');
   if (standalone) {
-    out.push(`> Exportado de [MasterWhats](${SITE}/#/chat/${entry.id}) em ${generatedAt.slice(0, 10)}. Código e dados: ${REPO}.`, '');
+    out.push(`> Exportado de [MasterWhats](${SITE}/#/chat/${entry.id}) em ${generatedAt.slice(0, 10)}.${month ? ` Só ${monthName(month)} (${messages.length} mensagens); a conversa inteira está em masterwhats-${entry.id}.md.` : ''} Código e dados: ${REPO}.`, '');
   }
 
   out.push(`${sub} Proveniência`, '', '| | |', '|---|---|');
   out.push(`| Fonte | ${source.label} |`);
   if (source.document) out.push(`| Documento | \`${source.document}\`${source.document_pages ? `, ${source.document_pages} páginas` : ''}${source.document_url ? ` — [no repositório](${source.document_url})` : ''} (sha256 \`${source.document_sha256 || 'n/d'}\`) |`);
   out.push(`| Como chegou ao público | ${source.how} |`);
-  out.push(`| Período | ${entry.date_range.start} a ${entry.date_range.end} |`);
-  out.push(`| Mensagens | ${entry.total_messages} |`);
+  out.push(`| Período | ${month ? `${messages[0].date} a ${messages.at(-1).date}` : `${entry.date_range.start} a ${entry.date_range.end}`} |`);
+  out.push(`| Mensagens | ${month ? `${messages.length} (de ${entry.total_messages} na conversa)` : entry.total_messages} |`);
   if (entry.saved_as) out.push(`| Contato salvo como | ${entry.saved_as} |`);
   if (entry.phone) out.push(`| Telefone | ${phonePretty(entry.phone)} |`);
   out.push(`| Fuso dos horários | ${TIMEZONE} (UTC${UTC_OFFSET}) |`);
@@ -255,6 +257,21 @@ for (const entry of entries) {
   zip.file(`masterwhats-${entry.id}.json`, jsonText);
   built.push({ entry, messages });
   console.log(`${entry.id}: ${messages.length} messages, ${(mdText.length / 1024).toFixed(0)} kB md`);
+
+  // A conversation too big for one page also comes one month at a time, so a
+  // reader after a single exchange does not have to take all of it.
+  if (isPaged(entry)) {
+    const months = new Map();
+    for (const m of messages) { const ym = m.date.slice(0, 7); if (!months.has(ym)) months.set(ym, []); months.get(ym).push(m); }
+    for (const [ym, msgs] of months) {
+      const monthMd = conversationMarkdown(entry, msgs, { month: ym });
+      const monthJson = JSON.stringify({ ...conversationJson(entry, msgs), month: ym }, null, 1);
+      writeFileSync(join(OUT, `masterwhats-${entry.id}-${ym}.md`), monthMd);
+      writeFileSync(join(OUT, `masterwhats-${entry.id}-${ym}.json`), monthJson);
+      zip.file(`meses/masterwhats-${entry.id}-${ym}.md`, monthMd);
+    }
+    console.log(`${entry.id}: ${months.size} monthly files`);
+  }
 }
 
 const allMd = allMarkdown(built);

--- a/scripts/lib/corpus.mjs
+++ b/scripts/lib/corpus.mjs
@@ -48,6 +48,7 @@ export function sourceOf(entry) {
       label: entry.source,
       document: doc.file || null,
       document_url: doc.url || null,
+      document_download: doc.download || null,
       document_sha256: doc.sha256 || null,
       document_pages: doc.pages || null,
       made_public: '2026-09-01',
@@ -128,10 +129,14 @@ export function mentionsOf(person, entries, messagesOf) {
   }));
   const found = new Map();
   for (const entry of entries) {
-    const hits = messagesOf(entry.id).filter(m => {
+    const hits = [];
+    for (const m of messagesOf(entry.id)) {
       const text = normalize(m.content || '');
-      return rules.some(r => (!r.only || r.only.has(entry.id)) && r.re.test(text) && !(r.unless && r.unless.test(text)));
-    });
+      const rule = rules.find(r => (!r.only || r.only.has(entry.id)) && r.re.test(text) && !(r.unless && r.unless.test(text)));
+      // Each hit remembers the alias that found it, so a page can say
+      // "8 by «gonet», 5 by «paulo»" instead of one inferred total.
+      if (rule) hits.push({ msg: m, alias: person.aliases[rules.indexOf(rule)].match });
+    }
     if (hits.length) found.set(entry.id, hits);
   }
   return found;

--- a/scripts/prerender.mjs
+++ b/scripts/prerender.mjs
@@ -273,6 +273,7 @@ function monthPage(entry, who, ym, msgs, prevYm, nextYm) {
     + (prevYm ? `<a href="${parent}/${prevYm}" rel="prev">${longMonth(prevYm)}</a> · ` : '')
     + (nextYm ? `<a href="${parent}/${nextYm}" rel="next">${longMonth(nextYm)}</a> · ` : '')
     + `<a href="/#/chat/${entry.id}/msg/${msgs[0].id}">Abrir no MasterWhats</a> · `
+    + `<a href="/export/masterwhats-${entry.id}-${ym}.md">Markdown deste mês</a> · `
     + `<a href="/export/masterwhats-${entry.id}.md">Markdown completo</a></p>`);
   out.push(...messagesHtml(msgs));
   out.push('</article>');
@@ -333,7 +334,7 @@ ${JSON.stringify(jsonLd, null, 2)}
 </head>
 <body>
 <main>
-<header><a href="/">MasterWhats</a> · <a href="/quem/">Pessoas citadas</a></header>
+<header><a href="/">MasterWhats</a> · <a href="/quem">Pessoas citadas</a></header>
 ${body}
 </main>
 </body>
@@ -341,10 +342,10 @@ ${body}
 `;
 }
 
-function mentionHtml(conversationId, msg) {
+function mentionHtml(conversationId, msg, alias, primary) {
   const cite = msg.source_page ? ` <small>(laudo p. ${msg.source_page}${msg.source_figure ? `, fig. ${msg.source_figure}` : ''})</small>` : '';
   return `<div class="msg" id="m-${conversationId}-${msg.id}">`
-    + `<time datetime="${msg.timestamp}${UTC_OFFSET}">${citationOf(msg).split(' · ')[0]}</time> · <b>${escapeHtml(msg.sender)}</b>${cite}<br>`
+    + `<time datetime="${msg.timestamp}${UTC_OFFSET}">${citationOf(msg).split(' · ')[0]}</time> · <b>${escapeHtml(msg.sender)}</b>${cite}${alias !== primary ? ` <small>· por «${escapeHtml(alias)}»</small>` : ''}<br>`
     + `${escapeHtml(messageText(msg))}<br>`
     + `<span class="links"><a href="${locate(conversationId, msg)}">ver na conversa</a> · <a href="${messageUrl(conversationId, msg)}">no app</a> · msg ${msg.id}</span>`
     + `</div>`;
@@ -354,16 +355,21 @@ function personPage(person, mentions) {
   const path = `/quem/${person.slug}`;
   const total = [...mentions.values()].reduce((n, v) => n + v.length, 0);
   const convs = [...mentions.keys()].map(id => byId.get(id));
+  const primary = person.aliases[0].match;
+  const byAlias = new Map();
+  for (const hits of mentions.values()) for (const { alias } of hits) byAlias.set(alias, (byAlias.get(alias) || 0) + 1);
+  // In the order the aliases are declared: the name first, the nicknames after.
+  const breakdown = person.aliases.filter(a => byAlias.has(a.match)).map(a => `${byAlias.get(a.match)} por «${a.match}»`).join(', ');
   const description = `${person.name}, ${person.role}: ${total} menções em ${convs.length} conversa${convs.length === 1 ? '' : 's'} dos celulares de Daniel Vorcaro — ${convs.map(contactOf).join(', ')}.`;
   const body = [];
   body.push(`<h1>${escapeHtml(person.name)}</h1>`);
   body.push(`<p class="role">${escapeHtml(person.role)}${person.profile ? ` · <a href="/chat/${person.profile}">perfil e conversa com Vorcaro</a>` : ''}</p>`);
-  body.push(`<p>${total} menções em ${convs.length} conversa${convs.length === 1 ? '' : 's'}. Cada uma linka a mensagem na conversa e no app; as do relatório da PF citam página e figura do laudo.</p>`);
-  body.push(`<p class="how">Como as mensagens se referem a essa pessoa: ${person.aliases.map(a => `<code>${escapeHtml(a.match)}</code>${a.only ? ` (só em ${a.only.map(id => contactOf(byId.get(id))).join(', ')})` : ''}`).join(', ')}.</p>`);
-  for (const [id, msgs] of mentions) {
+  body.push(`<p>${total} menções em ${convs.length} conversa${convs.length === 1 ? '' : 's'} — ${breakdown}. Cada uma linka a mensagem na conversa e no app; as do relatório da PF citam página e figura do laudo.</p>`);
+  body.push(`<p class="how">Como as mensagens se referem a essa pessoa: ${person.aliases.map(a => `<code>${escapeHtml(a.match)}</code>${a.only ? ` (só em ${a.only.map(id => contactOf(byId.get(id))).join(', ')})` : ''}`).join(', ')}. Uma menção achada por um apelido que não é o nome vem marcada.</p>`);
+  for (const [id, hits] of mentions) {
     const entry = byId.get(id);
-    body.push(`<h2><a href="/chat/${id}">Daniel Vorcaro ↔ ${escapeHtml(contactOf(entry))}</a> — ${msgs.length} men${msgs.length === 1 ? 'ção' : 'ções'}</h2>`);
-    for (const msg of msgs) body.push(mentionHtml(id, msg));
+    body.push(`<h2><a href="/chat/${id}">Daniel Vorcaro ↔ ${escapeHtml(contactOf(entry))}</a> — ${hits.length} men${hits.length === 1 ? 'ção' : 'ções'}</h2>`);
+    for (const { msg, alias } of hits) body.push(mentionHtml(id, msg, alias, primary));
   }
   const jsonLd = {
     '@context': 'https://schema.org',
@@ -388,10 +394,10 @@ function peopleIndex(people) {
   }
   body.push('</ul>');
   const jsonLd = {
-    '@context': 'https://schema.org', '@type': 'CollectionPage', '@id': `${SITE}/quem/`, url: `${SITE}/quem/`,
+    '@context': 'https://schema.org', '@type': 'CollectionPage', '@id': `${SITE}/quem`, url: `${SITE}/quem`,
     name: 'Pessoas citadas nas conversas de Daniel Vorcaro', inLanguage: 'pt-BR', isPartOf: { '@id': `${SITE}/#dataset` }, dateModified: today,
   };
-  return standalone({ title: 'Pessoas citadas — MasterWhats', description: 'Quem aparece nas conversas de Daniel Vorcaro, com toda menção datada e apontando para a mensagem.', path: '/quem/', jsonLd, body: body.join('\n') });
+  return standalone({ title: 'Pessoas citadas — MasterWhats', description: 'Quem aparece nas conversas de Daniel Vorcaro, com toda menção datada e apontando para a mensagem.', path: '/quem', jsonLd, body: body.join('\n') });
 }
 
 // ── llms-full.txt ──────────────────────────────────────────────────────────
@@ -422,7 +428,7 @@ function llmsFull(built, people) {
     const source = sourceOf(entry);
     out.push(`### ${who} — ${entry.total_messages} mensagens, ${entry.date_range.start} a ${entry.date_range.end}`, '');
     out.push(`- Página: ${SITE}/chat/${entry.id}`);
-    if (months) out.push(`- Um mês por página: ${[...months.keys()].map(ym => `${SITE}/chat/${entry.id}/${ym}`).join(' · ')}`);
+    if (months) out.push(`- Um mês por página: ${[...months.keys()].map(ym => `${SITE}/chat/${entry.id}/${ym}`).join(' · ')}`, `- Markdown por mês (troque o mês): ${SITE}/export/masterwhats-${entry.id}-${[...months.keys()][0]}.md`);
     out.push(`- Conversa completa em Markdown: ${SITE}/export/masterwhats-${entry.id}.md · JSON: ${SITE}/export/masterwhats-${entry.id}.json`);
     out.push(`- Fonte: ${source.label}`);
     if (entry.saved_as) out.push(`- Salvo no celular como: ${entry.saved_as}`);
@@ -430,9 +436,9 @@ function llmsFull(built, people) {
     out.push('');
     out.push(...profileParagraphs(profile, entry.id));
   }
-  out.push(`## Pessoas citadas (${people.length})`, '', `Índice em ${SITE}/quem/ — cada página lista toda menção, por conversa, datada e apontando para a mensagem.`, '');
+  out.push(`## Pessoas citadas (${people.length})`, '', `Índice em ${SITE}/quem — cada página lista toda menção, por conversa, datada e apontando para a mensagem.`, '');
   for (const { person, mentions } of people) {
-    const per = [...mentions].map(([id, msgs]) => `${contactOf(byId.get(id))} (${msgs.length})`).join(', ');
+    const per = [...mentions].map(([id, hits]) => `${contactOf(byId.get(id))} (${hits.length})`).join(', ');
     out.push(`- [${person.name}](${SITE}/quem/${person.slug}) — ${person.role}. Citado em: ${per}.`);
   }
   out.push('');
@@ -445,7 +451,7 @@ function llmsFull(built, people) {
     out.push('## Documento-fonte do relatório da PF', '',
       `- Arquivo: ${report.file} — ${report.pages} páginas`,
       `- sha256: ${report.sha256}`,
-      `- Onde obter: ${report.url} (o site não serve o PDF; o caminho acima é do repositório)`, '');
+      `- Onde obter: ${report.url} (página) ou ${report.download} (os bytes) — o site não serve o PDF; o caminho acima é do repositório`, '');
   }
   out.push('## Fontes gerais', '', ...SOURCES.map(s => `- [${s.label}](${s.url})`), '');
   out.push('## Export', '',
@@ -467,7 +473,7 @@ function sitemap(built, people) {
     rows.push(url(`${SITE}/chat/${entry.id}`, headline ? '0.9' : '0.8'));
     if (months) for (const ym of months.keys()) rows.push(url(`${SITE}/chat/${entry.id}/${ym}`, '0.6', 'monthly'));
   }
-  rows.push(url(`${SITE}/quem/`, '0.8'));
+  rows.push(url(`${SITE}/quem`, '0.8'));
   for (const { person } of people) rows.push(url(`${SITE}/quem/${person.slug}`, '0.7'));
   rows.push(url(`${SITE}/llms.txt`, '0.7'));
   rows.push(url(`${SITE}/llms-full.txt`, '0.7'));
@@ -517,7 +523,7 @@ writeFileSync(join(DIST, 'quem', 'index.html'), peopleIndex(people));
 
 // The sizes the index quotes decide whether a crawler downloads a file. They
 // are stamped from the files themselves rather than typed and forgotten.
-const mb = (name) => `${(statSync(join(DIST, 'export', name)).size / 1048576).toFixed(1)} MB`;
+const mb = (name) => `${(statSync(join(DIST, 'export', name)).size / 1e6).toFixed(1)} MB`;
 const SIZES = { 'masterwhats.md': mb('masterwhats.md'), 'masterwhats.json': mb('masterwhats.json'), 'masterwhats-export.zip': mb('masterwhats-export.zip') };
 const stampSizes = (text) => text.replace(/(masterwhats(?:-export)?\.(?:md|json|zip)) \([\d.,]+ MB\)/g, (m, name) => `${name} (${SIZES[name] || m.slice(name.length + 2, -1)})`);
 writeFileSync(join(DIST, 'llms.txt'), stampSizes(readFileSync(join(DIST, 'llms.txt'), 'utf-8')));

--- a/scripts/split_data.py
+++ b/scripts/split_data.py
@@ -151,6 +151,7 @@ def describe_report_document():
     return {
         "file": REPORT_PDF,
         "url": f"https://github.com/rafaelbressan/masterzap/blob/main/{REPORT_PDF}",
+        "download": f"https://raw.githubusercontent.com/rafaelbressan/masterzap/main/{REPORT_PDF}",
         "sha256": sha,
         "pages": pages,
     }
@@ -195,9 +196,12 @@ def split_conversation(conv_id, data, index):
     type_counts = Counter(msg["type"] for msg in messages)
 
     last_msg = messages[-1] if messages else None
+    other = [p for p in metadata["participants"] if p != "DV"]
     entry = {
         "id": conv_id,
         "participants": metadata["participants"],
+        # The other side, by name, so nobody has to know "the one that is not DV".
+        "contact": other[0] if other else metadata["participants"][0],
         "date_range": normalise_date_range(metadata["date_range"]),
         "total_messages": metadata["total_messages"],
         # Drives the "Mídias, links e documentos" count in the contact drawer.

--- a/src/lib/people-content.js
+++ b/src/lib/people-content.js
@@ -21,7 +21,7 @@ export const PEOPLE = [
     slug: 'paulo-gonet',
     name: 'Paulo Gonet',
     role: 'Procurador-geral da República',
-    aliases: [{ match: 'gonet' }, { match: 'paulo', only: ['alexandre-de-moraes'] }],
+    aliases: [{ match: 'gonet', unless: 'pedro gonet|pedrinho' }, { match: 'paulo', only: ['alexandre-de-moraes'] }],
   },
   {
     slug: 'alexandre-de-moraes',

--- a/tests/unit/conversations-data.test.js
+++ b/tests/unit/conversations-data.test.js
@@ -35,6 +35,12 @@ describe('conversations.json', () => {
     }
   });
 
+  it('names the contact as a field, not as "the participant that is not DV"', () => {
+    for (const conv of conversations) {
+      expect(conv.contact, conv.id).toBe(conv.participants.find(p => p !== 'DV') || conv.participants[0]);
+    }
+  });
+
   it('has a positive message count everywhere', () => {
     for (const conv of conversations) {
       expect(conv.total_messages, conv.id).toBeGreaterThan(0);
@@ -141,6 +147,7 @@ describe('the police report as a document', () => {
       expect(conv.source_document?.pages, conv.id).toBeGreaterThan(0);
       expect(conv.source_document?.file, conv.id).toMatch(/\.pdf$/);
       expect(conv.source_document?.url, conv.id).toMatch(/^https:\/\/github\.com\/.*\.pdf$/);
+      expect(conv.source_document?.download, conv.id).toMatch(/^https:\/\/raw\.githubusercontent\.com\/.*\.pdf$/);
     }
   });
 

--- a/tests/unit/export-data.test.js
+++ b/tests/unit/export-data.test.js
@@ -119,6 +119,24 @@ describe('the Markdown', () => {
   });
 });
 
+describe('the big conversation, one month at a time', () => {
+  it('writes a Markdown and a JSON per month, each saying what it is', () => {
+    const md = readFileSync(join(EXPORT_DIR, 'masterwhats-martha-graeff-2024-12.md'), 'utf-8');
+    expect(md).toMatch(/^# Daniel Vorcaro ↔ Martha Graeff — dezembro de 2024/);
+    expect(md).toContain('· msg 35686');
+    expect(md).toContain('(de 65772 na conversa)');
+    const lines = md.split('\n').filter(l => /^\*\*.+\*\* · (\d{4}-\d{2})-\d{2} /.test(l));
+    expect(new Set(lines.map(l => l.match(/· (\d{4}-\d{2})-/)[1]))).toEqual(new Set(['2024-12']));
+    const j = JSON.parse(readFileSync(join(EXPORT_DIR, 'masterwhats-martha-graeff-2024-12.json'), 'utf-8'));
+    expect(j.month).toBe('2024-12');
+    expect(j.messages.length).toBe(lines.length);
+  });
+
+  it('does not split the small ones', () => {
+    expect(existsSync(join(EXPORT_DIR, 'masterwhats-ciro-soares-2025-03.md'))).toBe(false);
+  });
+});
+
 describe('everything at once', () => {
   it('writes one Markdown with every conversation in it', () => {
     const text = readFileSync(join(EXPORT_DIR, 'masterwhats.md'), 'utf-8');

--- a/tests/unit/prerender.test.js
+++ b/tests/unit/prerender.test.js
@@ -168,8 +168,12 @@ describe('people', () => {
   it('lists every mention by conversation, dated, pointing at the message', () => {
     const html = person('paulo-gonet');
     expect(html).toContain('<h1>Paulo Gonet</h1>');
+    // Counts say which alias found what; a hit by an alias is marked.
+    expect(html).toMatch(/\d+ por «gonet», \d+ por «paulo»/);
+    expect(html).toContain('· por «paulo»</small>');
+    // The son is not the father.
+    expect(html).not.toContain('Pedro Gonet');
     expect(html).toContain('Daniel Vorcaro ↔ Ciro Soares</a>');
-    expect(html).toContain('Daniel Vorcaro ↔ Ana Matos');
     expect(html).toContain('href="/chat/ciro-soares#msg-34"');
     expect(html).toContain('href="https://www.masterwhats.com.br/#/chat/ciro-soares/msg/34"');
     expect(html).toContain('laudo p. 207, fig. 219');
@@ -192,7 +196,8 @@ describe('people', () => {
 
   it('is in the sitemap and in llms-full.txt', () => {
     const xml = readFileSync(join(DIST, 'sitemap.xml'), 'utf-8');
-    expect(xml).toContain(`<loc>${SITE}/quem/</loc>`);
+    expect(xml).toContain(`<loc>${SITE}/quem</loc>`);
+    expect(xml).not.toContain(`<loc>${SITE}/quem/</loc>`);
     expect(xml).toContain(`<loc>${SITE}/quem/paulo-gonet</loc>`);
     expect(xml).toContain(`<loc>${SITE}/chat/martha-graeff/2024-12</loc>`);
     const t = readFileSync(join(DIST, 'llms-full.txt'), 'utf-8');
@@ -214,7 +219,7 @@ describe('the home page', () => {
 describe('llms.txt', () => {
   it('quotes the real size of the big files', () => {
     const t = readFileSync(join(DIST, 'llms.txt'), 'utf-8');
-    const real = (statSync(join(DIST, 'export/masterwhats.md')).size / 1048576).toFixed(1);
+    const real = (statSync(join(DIST, 'export/masterwhats.md')).size / 1e6).toFixed(1);
     expect(t).toContain(`masterwhats.md (${real} MB)`);
   });
 });

--- a/vercel.json
+++ b/vercel.json
@@ -3,7 +3,7 @@
   "redirects": [
     {
       "source": "/data/source/(.*)",
-      "destination": "https://github.com/rafaelbressan/masterzap/blob/main/data/source/$1",
+      "destination": "https://raw.githubusercontent.com/rafaelbressan/masterzap/main/data/source/$1",
       "permanent": false
     }
   ],


### PR DESCRIPTION
Do quinto teste com agente-crawler (4/5; as quatro respostas em **~614 KB** contra 10,4 MB no quarto). Ele cobrou precisão onde o site já respondia:

- **Pessoas por apelido.** A contagem somava "Pedro Gonet" (o filho) ao pai e inferia "Paulo" sem dizer no total. `mentionsOf` devolve `{msg, alias}`; a página abre com "7 por «gonet», 5 por «paulo»", marca cada menção achada por apelido, e o filho sai da conta (`unless: 'pedro gonet|pedrinho'`).
- **Export por mês** da conversa grande: `masterwhats-martha-graeff-<YYYY-MM>.md/.json` (19), linkados da página do mês e do `llms-full`. Duas mensagens de contexto não custam mais 524 KB.
- **PDF em bytes**: `/data/source/*.pdf` redireciona pro `raw.githubusercontent.com`, não pra página `blob`; `source_document.download` e `llms.txt` dizem os dois.
- **`contact`** em `conversations.json` — ninguém precisa saber "o participante que não é DV".
- **`/quem` canônico** sem barra (o Vercel já servia assim; llms, sitemap e JSON-LD apontavam com barra).
- **Tamanhos em MB decimal**, como o `curl` mede.

231 unit (+3), 261 E2E.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RPgDUnTk2JuejAso8UHMWb