### PR TITLE
Tela de Chamadas: toda ligação registrada, quem ligou, e o caminho até ela no chat

### DIFF
--- a/scripts/split_data.py
+++ b/scripts/split_data.py
@@ -157,6 +157,47 @@ def describe_report_document():
     }
 
 
+CALL_RE_PT = re.compile(r"^Chamada de (voz|v[ií]deo)(?: — duração (\d{1,2}:\d{2}))?( perdida)?", re.I)
+CALL_RE_EN = re.compile(r"^(Missed )?(Voice|Video) call(?:, (\d+) (min|sec)|, (No answer)|, (Ended)|, (Tap to call back))?", re.I)
+
+
+def describe_call(msg):
+    """One call as the calls screen needs it: direction, kind, how it ended, how long.
+
+    The Martha export writes calls in English ("Voice call, 3 min", "Missed
+    video call, Tap to call back", "Voice call, No answer"); the police report
+    in Portuguese ("Chamada de voz — duração 02:49", "Chamada de voz perdida").
+    Both become the same record. Returns None for a line that is not a call.
+    """
+    text = (msg.get("content") or "").strip()
+    kind, status, duration = None, None, None
+    m = CALL_RE_PT.match(text)
+    if m:
+        kind = "video" if m.group(1).lower().startswith("v") and "d" in m.group(1).lower() else "voice"
+        duration = m.group(2)
+        status = "missed" if m.group(3) else ("completed" if duration else "ended")
+    else:
+        m = CALL_RE_EN.match(text)
+        if not m:
+            return None
+        kind = m.group(2).lower()
+        if m.group(1) or m.group(7):
+            status = "missed"
+        elif m.group(5):
+            status = "no_answer"
+        elif m.group(3):
+            status = "completed"
+            duration = f"{m.group(3)} {'min' if m.group(4).lower().startswith('min') else 's'}"
+        else:
+            status = "ended"
+    return {
+        "kind": kind,
+        "status": status,
+        "duration": duration,
+        "outgoing": msg.get("sender") == "DV",
+    }
+
+
 def normalise_date_range(date_range):
     """Always {"start": ..., "end": ...}.
 
@@ -189,6 +230,19 @@ def split_conversation(conv_id, data, index):
 
     for date in dates:
         write_json(conv_dir / f"{date}.json", {"messages": by_date[date]})
+
+    for msg in messages:
+        if msg["type"] != "call":
+            continue
+        call = describe_call(msg)
+        if call:
+            CALLS.append({
+                "conversation_id": conv_id,
+                "message_id": msg["id"],
+                "date": msg["date"],
+                "timestamp": msg["timestamp"],
+                **call,
+            })
 
     print(f"{conv_id}: {len(messages)} messages, {len(dates)} dates, "
           f"search index {size_mb:.1f} MB")
@@ -225,6 +279,7 @@ def split_conversation(conv_id, data, index):
 
 
 REPORT_DOCUMENT = None
+CALLS = []
 
 
 def main():
@@ -250,6 +305,11 @@ def main():
     entries.sort(key=lambda e: e["last_message"]["timestamp"] if e["last_message"] else "",
                  reverse=True)
     write_json(OUTPUT_DIR / "conversations.json", {"conversations": entries})
+
+    # Every call, newest first — the calls screen reads this one file.
+    CALLS.sort(key=lambda c: c["timestamp"], reverse=True)
+    write_json(OUTPUT_DIR / "calls.json", {"calls": CALLS})
+    print(f"calls.json: {len(CALLS)} calls")
 
     total = sum(e["total_messages"] for e in entries)
     print(f"\nDone! {len(entries)} conversations, {total} messages in {OUTPUT_DIR}")

--- a/src/components/CallsPanel.js
+++ b/src/components/CallsPanel.js
@@ -1,0 +1,184 @@
+/**
+ * The Calls screen: every call Vorcaro made or received that the material
+ * records, newest first, the way WhatsApp lists them.
+ *
+ * A row is a contact, an arrow saying who called whom (red when a call came
+ * in and was missed), the date and time, and the kind of call at the right.
+ * Consecutive calls with the same person on the same day fold into one row
+ * with a count, as on the phone. Tapping the row or the icon goes to the
+ * message in the chat where that call is — there is nothing to call back.
+ *
+ * The buttons across the top are drawn for fidelity and disabled: this is a
+ * record, not a phone.
+ *
+ * Security note: names come from the data and go in as textContent; the only
+ * innerHTML is static SVG.
+ */
+
+import { defaultAvatarSvg } from '../lib/avatar.js';
+import { ICON_SEARCH, ICON_MEETBALL } from '../lib/icons.js';
+
+const ICON_PHONE = `<svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72c.13.96.36 1.9.7 2.81a2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45c.91.34 1.85.57 2.81.7A2 2 0 0 1 22 16.92z"/></svg>`;
+const ICON_VIDEO = `<svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="m22 8-6 4 6 4V8Z"/><rect x="2" y="6" width="14" height="12" rx="2"/></svg>`;
+const ICON_CALENDAR = `<svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>`;
+const ICON_KEYPAD = `<svg viewBox="0 0 24 24" width="24" height="24" fill="currentColor"><circle cx="6" cy="5" r="2"/><circle cx="12" cy="5" r="2"/><circle cx="18" cy="5" r="2"/><circle cx="6" cy="12" r="2"/><circle cx="12" cy="12" r="2"/><circle cx="18" cy="12" r="2"/><circle cx="6" cy="19" r="2"/><circle cx="12" cy="19" r="2"/><circle cx="18" cy="19" r="2"/></svg>`;
+const ICON_HEART = `<svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linejoin="round"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>`;
+const ICON_OUT = `<svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 17 17 7"/><path d="M8 7h9v9"/></svg>`;
+const ICON_IN = `<svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M17 7 7 17"/><path d="M16 17H7V8"/></svg>`;
+
+const dayFmt = new Intl.DateTimeFormat('pt-BR', { day: 'numeric', month: 'short', year: 'numeric' });
+
+/** "12 de jul. de 2024, 15:42" */
+export function formatCallTime(timestamp) {
+  const d = new Date(timestamp);
+  const time = `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;
+  return `${dayFmt.format(d)}, ${time}`;
+}
+
+/**
+ * Fold consecutive calls with the same contact on the same day into one row.
+ * @returns {{ call: object, count: number }[]} newest first, `call` the latest
+ */
+export function groupCalls(calls) {
+  const rows = [];
+  for (const call of calls) {
+    const last = rows[rows.length - 1];
+    if (last && last.call.conversation_id === call.conversation_id && last.call.date === call.date
+      && last.call.outgoing === call.outgoing && last.call.status === call.status) {
+      last.count += 1;
+      last.oldest = call;
+    } else {
+      rows.push({ call, count: 1, oldest: call });
+    }
+  }
+  return rows;
+}
+
+/** What the row says under the name. */
+function describe(call) {
+  const parts = [];
+  if (call.status === 'missed') parts.push(call.outgoing ? 'Não atendida' : 'Perdida');
+  else if (call.status === 'no_answer') parts.push('Sem resposta');
+  else if (call.duration) parts.push(call.duration.includes(':') ? `duração ${call.duration}` : call.duration);
+  return parts.join(' · ');
+}
+
+/**
+ * @param {object} o
+ * @param {object[]} o.calls - from calls.json, newest first
+ * @param {object[]} o.conversations
+ * @param {function} o.avatarFor - conversation id → image URL or null
+ * @param {function} o.onOpen - (conversationId, messageId)
+ * @returns {HTMLElement}
+ */
+export function renderCallsPanel({ calls, conversations, avatarFor, onOpen }) {
+  const byId = new Map(conversations.map(c => [c.id, c]));
+  const nameOf = (id) => byId.get(id)?.contact || byId.get(id)?.participants?.find(p => p !== 'DV') || id;
+
+  const panel = document.createElement('section');
+  panel.className = 'calls-panel';
+  panel.setAttribute('aria-label', 'Chamadas');
+
+  const header = document.createElement('div');
+  header.className = 'calls-header';
+  const title = document.createElement('h2');
+  title.className = 'calls-title';
+  title.textContent = 'Chamadas';
+  header.appendChild(title);
+  for (const [icon, label] of [[ICON_SEARCH, 'Pesquisar chamadas'], [ICON_MEETBALL, 'Menu']]) {
+    const b = document.createElement('button');
+    b.className = 'calls-header-btn';
+    b.disabled = true;
+    b.setAttribute('aria-label', label);
+    b.innerHTML = icon;
+    header.appendChild(b);
+  }
+  panel.appendChild(header);
+
+  // The row of actions WhatsApp puts on top. None of them can do anything
+  // here, and they say so.
+  const actions = document.createElement('div');
+  actions.className = 'calls-actions';
+  for (const [icon, label] of [[ICON_PHONE, 'Ligar'], [ICON_CALENDAR, 'Agendar'], [ICON_KEYPAD, 'Teclado'], [ICON_HEART, 'Favoritos']]) {
+    const b = document.createElement('button');
+    b.className = 'calls-action';
+    b.disabled = true;
+    b.setAttribute('aria-label', label);
+    b.innerHTML = `<span class="calls-action-icon">${icon}</span><span class="calls-action-label">${label}</span>`;
+    actions.appendChild(b);
+  }
+  panel.appendChild(actions);
+
+  const heading = document.createElement('h3');
+  heading.className = 'calls-recent';
+  heading.textContent = 'Recentes';
+  panel.appendChild(heading);
+
+  const list = document.createElement('div');
+  list.className = 'calls-list';
+  list.setAttribute('role', 'list');
+  for (const { call, count } of groupCalls(calls)) {
+    list.appendChild(renderRow(call, count, nameOf(call.conversation_id), avatarFor(call.conversation_id), onOpen));
+  }
+  panel.appendChild(list);
+
+  const foot = document.createElement('p');
+  foot.className = 'calls-foot';
+  foot.textContent = `${calls.length} chamadas registradas no material. Tocar numa chamada abre a conversa no ponto em que ela aconteceu.`;
+  panel.appendChild(foot);
+  return panel;
+}
+
+function renderRow(call, count, name, avatar, onOpen) {
+  const row = document.createElement('div');
+  row.className = `calls-item${call.status === 'missed' && !call.outgoing ? ' missed' : ''}`;
+  row.setAttribute('role', 'listitem');
+  row.dataset.conversation = call.conversation_id;
+  row.dataset.message = call.message_id;
+  const open = () => onOpen(call.conversation_id, call.message_id);
+
+  const main = document.createElement('button');
+  main.className = 'calls-item-main';
+  main.addEventListener('click', open);
+
+  const av = document.createElement('span');
+  av.className = 'calls-item-avatar';
+  if (avatar) {
+    const img = document.createElement('img');
+    img.src = avatar;
+    img.alt = name;
+    av.appendChild(img);
+  } else {
+    av.innerHTML = defaultAvatarSvg(name, 48);
+  }
+  main.appendChild(av);
+
+  const text = document.createElement('span');
+  text.className = 'calls-item-text';
+  const who = document.createElement('span');
+  who.className = 'calls-item-name';
+  who.textContent = count > 1 ? `${name} (${count})` : name;
+  text.appendChild(who);
+  const meta = document.createElement('span');
+  meta.className = 'calls-item-meta';
+  const arrow = document.createElement('span');
+  arrow.className = `calls-item-arrow ${call.outgoing ? 'out' : 'in'}`;
+  arrow.setAttribute('aria-label', call.outgoing ? 'Chamada feita' : 'Chamada recebida');
+  arrow.innerHTML = call.outgoing ? ICON_OUT : ICON_IN;
+  meta.appendChild(arrow);
+  const when = document.createElement('span');
+  const detail = describe(call);
+  when.textContent = detail ? `${formatCallTime(call.timestamp)} · ${detail}` : formatCallTime(call.timestamp);
+  meta.appendChild(when);
+  text.appendChild(meta);
+  main.appendChild(text);
+  row.appendChild(main);
+
+  const kind = document.createElement('button');
+  kind.className = 'calls-item-kind';
+  kind.setAttribute('aria-label', call.kind === 'video' ? 'Chamada de vídeo — ver na conversa' : 'Chamada de voz — ver na conversa');
+  kind.innerHTML = call.kind === 'video' ? ICON_VIDEO : ICON_PHONE;
+  kind.addEventListener('click', open);
+  row.appendChild(kind);
+  return row;
+}

--- a/src/components/NavRail.js
+++ b/src/components/NavRail.js
@@ -7,6 +7,7 @@
 
 const ICON_CHAT = `<svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z"/></svg>`;
 const ICON_STATUS = `<svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="1.5"><circle cx="12" cy="12" r="10"/><path d="M12 8v4l3 3"/></svg>`;
+const ICON_CALLS = `<svg viewBox="0 0 32 32" width="24" height="24" fill="currentColor"><path d="M22.246 27.236C18.8584 27.236 14.7666 25.0019 11.0269 21.2743C7.27502 17.5225 5.06519 13.4185 5.06519 10.0066C5.06519 8.08819 5.62371 6.67972 6.93504 5.46553C7.02004 5.39268 7.09289 5.31983 7.16574 5.25912C7.94282 4.5306 8.75633 4.16634 9.49699 4.17849C10.2862 4.20277 11.0147 4.62774 11.6461 5.55052L14.0745 9.07168C14.7666 10.0673 14.8759 11.2451 13.8438 12.3014L12.9696 13.1878C12.7025 13.4549 12.6539 13.7463 12.836 14.0742C13.3217 14.9241 14.1231 15.8347 15.2523 16.9639C16.2843 17.996 17.6321 19.1009 18.227 19.4652C18.5549 19.6473 18.8463 19.5987 19.1134 19.3316L19.9998 18.4574C21.0561 17.4253 22.2339 17.5346 23.2295 18.2267L26.7507 20.6551C27.6735 21.2865 28.1227 22.015 28.1227 22.8042C28.1227 23.5449 27.7706 24.3462 27.0421 25.1355C26.9814 25.2083 26.9085 25.2812 26.8357 25.3661C25.6093 26.6896 24.1887 27.236 22.246 27.236Z"/></svg>`;
 const ICON_CHANNELS = `<svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 00-3-3.87"/><path d="M16 3.13a4 4 0 010 7.75"/></svg>`;
 const ICON_SETTINGS = `<svg viewBox="0 0 24 24" width="24" height="24" fill="currentColor"><path fill-rule="evenodd" clip-rule="evenodd" d="M9.66248 21.55C9.98748 21.85 10.375 22 10.825 22H13.175C13.625 22 14.0125 21.85 14.3375 21.55C14.6625 21.25 14.8583 20.8833 14.925 20.45L15.15 18.8C15.35 18.7167 15.55 18.6167 15.75 18.5C15.95 18.3833 16.1416 18.2583 16.325 18.125L17.825 18.775C18.2416 18.9583 18.6583 18.975 19.075 18.825C19.4916 18.675 19.8166 18.4083 20.05 18.025L21.25 15.975C21.4833 15.5917 21.55 15.1833 21.45 14.75C21.35 14.3167 21.125 13.9583 20.775 13.675L19.45 12.675C19.4833 12.5583 19.5 12.4458 19.5 12.3375V11.6625C19.5 11.5542 19.4916 11.4417 19.475 11.325L20.8 10.325C21.15 10.0417 21.375 9.68333 21.475 9.25C21.575 8.81667 21.5083 8.40833 21.275 8.025L20.1 5.975C19.8666 5.59167 19.5416 5.325 19.125 5.175C18.7083 5.025 18.2916 5.04167 17.875 5.225L16.325 5.875C16.1416 5.74167 15.9541 5.61667 15.7625 5.5C15.5708 5.38333 15.3666 5.28333 15.15 5.2L14.925 3.55C14.8583 3.11667 14.6625 2.75 14.3375 2.45C14.0125 2.15 13.625 2 13.175 2H10.825C10.375 2 9.98748 2.15 9.66248 2.45C9.33748 2.75 9.14165 3.11667 9.07498 3.55L8.84998 5.2C8.64998 5.28333 8.44998 5.38333 8.24998 5.5C8.04998 5.61667 7.85831 5.74167 7.67498 5.875L6.12498 5.225C5.70831 5.04167 5.29165 5.025 4.87498 5.175C4.45831 5.325 4.13331 5.59167 3.89998 5.975L2.72498 8.025C2.49165 8.40833 2.42498 8.81667 2.52498 9.25C2.62498 9.68333 2.84998 10.0417 3.19998 10.325L4.52498 11.325C4.50831 11.4417 4.49998 11.5542 4.49998 11.6625V12.3375C4.49998 12.4458 4.50831 12.5583 4.52498 12.675L3.19998 13.675C2.84998 13.9583 2.62498 14.3167 2.52498 14.75C2.42498 15.1833 2.49165 15.5917 2.72498 15.975L3.89998 18.025C4.13331 18.4083 4.45831 18.675 4.87498 18.825C5.29165 18.975 5.70831 18.9583 6.12498 18.775L7.67498 18.125C7.85831 18.2583 8.04581 18.3833 8.23748 18.5C8.42915 18.6167 8.63331 18.7167 8.84998 18.8L9.07498 20.45C9.14165 20.8833 9.33748 21.25 9.66248 21.55ZM12 15C12.8286 15 13.5357 14.7071 14.1214 14.1214C14.7071 13.5357 15 12.8286 15 12C15 11.1714 14.7071 10.4643 14.1214 9.87857C13.5357 9.29286 12.8286 9 12 9C11.1571 9 10.4464 9.29286 9.86786 9.87857C9.28929 10.4643 9 11.1714 9 12C9 12.8286 9.28929 13.5357 9.86786 14.1214C10.4464 14.7071 11.1571 15 12 15Z"/></svg>`;
 
@@ -17,7 +18,7 @@ const ICON_SETTINGS = `<svg viewBox="0 0 24 24" width="24" height="24" fill="cur
  * @param {string} [options.avatarSrc] - user avatar image URL
  * @returns {HTMLElement}
  */
-export function renderNavRail(container, { avatarSrc, onSettings, onChat } = {}) {
+export function renderNavRail(container, { avatarSrc, onSettings, onChat, onCalls } = {}) {
   const rail = document.createElement('nav');
   rail.className = 'nav-rail';
   rail.setAttribute('aria-label', 'Navegação');
@@ -30,6 +31,7 @@ export function renderNavRail(container, { avatarSrc, onSettings, onChat } = {})
     { icon: ICON_CHAT, label: 'Conversas', active: true, enabled: true },
     { icon: ICON_STATUS, label: 'Status', active: false, enabled: false },
     { icon: ICON_CHANNELS, label: 'Comunidades', active: false, enabled: false },
+    { icon: ICON_CALLS, label: 'Chamadas', active: false, enabled: true, calls: true },
   ];
 
   for (const item of navItems) {
@@ -41,6 +43,7 @@ export function renderNavRail(container, { avatarSrc, onSettings, onChat } = {})
     btn.setAttribute('title', item.label);
     btn.innerHTML = item.icon; // Static SVG
     if (item.active && onChat) btn.addEventListener('click', onChat);
+    if (item.calls && onCalls) btn.addEventListener('click', onCalls);
     topSection.appendChild(btn);
   }
 
@@ -72,6 +75,15 @@ export function renderNavRail(container, { avatarSrc, onSettings, onChat } = {})
   rail.appendChild(bottomSection);
 
   // Insert as first child of container
+  /** Move the highlight between the chat list and the calls screen. */
+  rail.setActive = (which) => {
+    for (const btn of rail.querySelectorAll('button[aria-label]')) {
+      const label = btn.getAttribute('aria-label');
+      if (label === 'Conversas') btn.classList.toggle('active', which === 'chats');
+      if (label === 'Chamadas') btn.classList.toggle('active', which === 'calls');
+    }
+  };
+
   container.insertBefore(rail, container.firstChild);
   return rail;
 }

--- a/src/components/Sidebar.js
+++ b/src/components/Sidebar.js
@@ -22,7 +22,7 @@ export const FAVORITE_CONVERSATIONS = new Set(['alexandre-de-moraes', 'martha-gr
  * @param {function} options.onSelect - called with conversation id
  * @param {Set<string>} [options.readConversations] - ids already opened
  */
-export function renderSidebar(container, { conversations, onSelect, onProfile, onAbout, onExportAll, readConversations = new Set() }) {
+export function renderSidebar(container, { conversations, onSelect, onProfile, onAbout, onExportAll, onCalls, onChats, readConversations = new Set() }) {
   const el = document.createElement('aside');
   el.className = 'sidebar';
   el.setAttribute('role', 'navigation');
@@ -217,20 +217,37 @@ export function renderSidebar(container, { conversations, onSelect, onProfile, o
   bottomNav.className = 'sidebar-bottom-nav';
   // Static SVG icons from design system — safe innerHTML
   bottomNav.innerHTML = `
-    <div class="sidebar-bottom-tab active">
+    <button class="sidebar-bottom-tab active" data-tab="chats">
       <svg viewBox="0 0 32 32" width="24" height="24" fill="currentColor"><path fill-rule="evenodd" clip-rule="evenodd" d="M4.87666 26.2151L4.87341 26.2197L4.87321 26.2199C4.706 26.4546 4.68382 26.7629 4.81573 27.0191C4.9477 27.2753 5.21177 27.4363 5.49999 27.4363H5.50082H5.5017L5.50365 27.4363L5.50821 27.4363L5.52001 27.4361C5.52906 27.436 5.54047 27.4357 5.55417 27.4352C5.58157 27.4343 5.61815 27.4326 5.66334 27.4294C5.75371 27.423 5.87867 27.4108 6.03375 27.3875C6.34391 27.3409 6.77501 27.2498 7.29101 27.072C8.31884 26.7177 9.67288 26.0227 11.0709 24.6667C11.4506 24.6956 11.8354 24.7104 12.2244 24.7104C18.6653 24.7104 24.2185 20.5799 24.2185 15.1216C24.2185 9.66321 18.6653 5.53272 12.2244 5.53272C5.7835 5.53272 0.230316 9.66321 0.230316 15.1216C0.230316 18.2149 2.04624 20.9077 4.75611 22.6306C5.08489 22.8396 5.42735 23.0348 5.78209 23.2153C5.90866 23.2797 5.9714 23.3611 5.98185 23.5782C5.99459 23.843 5.90966 24.2111 5.7393 24.6369C5.57476 25.0481 5.35835 25.4455 5.17802 25.746C5.08884 25.8946 5.01071 26.0158 4.95561 26.0988C4.92811 26.1403 4.90648 26.172 4.89224 26.1926L4.88655 26.2009L4.87666 26.2151Z"/></svg>
       <span>Conversas</span>
-    </div>
+    </button>
     <div class="sidebar-bottom-tab disabled">
       <svg viewBox="0 0 32 32" width="24" height="24" fill="currentColor"><path fill-rule="evenodd" clip-rule="evenodd" d="M16 6.96672C14.4004 6.96672 12.9667 8.43169 12.9667 10.4167C12.9667 12.4018 14.4004 13.8667 16 13.8667C17.5996 13.8667 19.0333 12.4018 19.0333 10.4167C19.0333 8.43169 17.5996 6.96672 16 6.96672ZM11.3667 10.4167C11.3667 7.70734 13.3654 5.36672 16 5.36672C18.6346 5.36672 20.6333 7.70734 20.6333 10.4167C20.6333 13.1261 18.6346 15.4667 16 15.4667C13.3654 15.4667 11.3667 13.1261 11.3667 10.4167ZM9.91579 21.1994C8.65548 22.3383 8.01768 23.7137 7.70973 24.6403L7.70593 24.6567L7.70738 24.659L7.709 24.6611C7.7181 24.6725 7.75003 24.7001 7.8159 24.7001H24.1841C24.25 24.7001 24.2819 24.6725 24.291 24.6611L24.2941 24.6567L24.2903 24.6403C23.9823 23.7137 23.3445 22.3383 22.0842 21.1994C20.8409 20.0757 18.9392 19.1334 16 19.1334C13.0609 19.1334 11.1592 20.0757 9.91579 21.1994ZM8.843 20.0123C10.3926 18.6119 12.6811 17.5334 16 17.5334C19.3189 17.5334 21.6074 18.6119 23.157 20.0123C24.6897 21.3974 25.4476 23.0493 25.8086 24.1357C26.1997 25.3124 25.2471 26.3001 24.1841 26.3001H7.8159C6.75296 26.3001 5.80034 25.3124 6.19138 24.1357C6.55243 23.0493 7.31034 21.3974 8.843 20.0123Z"/></svg>
       <span>Comunidades</span>
     </div>
-    <div class="sidebar-bottom-tab disabled">
+    <button class="sidebar-bottom-tab" data-tab="calls">
       <svg viewBox="0 0 32 32" width="24" height="24" fill="currentColor"><path d="M22.246 27.236C18.8584 27.236 14.7666 25.0019 11.0269 21.2743C7.27502 17.5225 5.06519 13.4185 5.06519 10.0066C5.06519 8.08819 5.62371 6.67972 6.93504 5.46553C7.02004 5.39268 7.09289 5.31983 7.16574 5.25912C7.94282 4.5306 8.75633 4.16634 9.49699 4.17849C10.2862 4.20277 11.0147 4.62774 11.6461 5.55052L14.0745 9.07168C14.7666 10.0673 14.8759 11.2451 13.8438 12.3014L12.9696 13.1878C12.7025 13.4549 12.6539 13.7463 12.836 14.0742C13.3217 14.9241 14.1231 15.8347 15.2523 16.9639C16.2843 17.996 17.6321 19.1009 18.227 19.4652C18.5549 19.6473 18.8463 19.5987 19.1134 19.3316L19.9998 18.4574C21.0561 17.4253 22.2339 17.5346 23.2295 18.2267L26.7507 20.6551C27.6735 21.2865 28.1227 22.015 28.1227 22.8042C28.1227 23.5449 27.7706 24.3462 27.0421 25.1355C26.9814 25.2083 26.9085 25.2812 26.8357 25.3661C25.6093 26.6896 24.1887 27.236 22.246 27.236Z"/></svg>
       <span>Chamadas</span>
-    </div>
+    </button>
   `;
   el.appendChild(bottomNav);
+  bottomNav.querySelector('[data-tab="chats"]').addEventListener('click', () => onChats?.());
+  bottomNav.querySelector('[data-tab="calls"]').addEventListener('click', () => onCalls?.());
+
+  /**
+   * Swap the list for the calls screen and back. The header, search and
+   * filter tabs belong to the chat list; the calls panel brings its own.
+   */
+  el.showCalls = (panel) => {
+    el.querySelector('.calls-panel')?.remove();
+    el.insertBefore(panel, bottomNav);
+    el.classList.add('sidebar--calls');
+    for (const tab of bottomNav.querySelectorAll('.sidebar-bottom-tab')) tab.classList.toggle('active', tab.dataset.tab === 'calls');
+  };
+  el.showChats = () => {
+    el.classList.remove('sidebar--calls');
+    for (const tab of bottomNav.querySelectorAll('.sidebar-bottom-tab')) tab.classList.toggle('active', tab.dataset.tab === 'chats');
+  };
 
   // Sidebar 3-dot menu (mobile only, hidden on desktop via CSS)
   const menuBtn = el.querySelector('.sidebar-menu-btn');

--- a/src/lib/router.js
+++ b/src/lib/router.js
@@ -41,7 +41,9 @@ export class HashRouter {
    * @param {string|number} [messageId]
    */
   navigate(route, param, messageId) {
-    if (route === 'home') {
+    if (route === 'calls') {
+      window.location.hash = '#/calls';
+    } else if (route === 'home') {
       window.location.hash = '#/';
     } else if (route === 'chat' && param) {
       if (messageId) {
@@ -65,6 +67,7 @@ export class HashRouter {
   static parseHash(hash) {
     const cleaned = hash.replace(/^#\/?/, '');
     if (!cleaned) return { route: 'home', param: null, messageId: null };
+    if (cleaned === 'calls') return { route: 'calls', param: null, messageId: null };
 
     // Match #/chat/:id/msg/:msgId
     const msgMatch = cleaned.match(/^chat\/([^/]+)\/msg\/(.+)$/);

--- a/src/main.js
+++ b/src/main.js
@@ -21,6 +21,7 @@ import {
   shareImageFile, canShareFiles,
 } from './lib/screenshot.js';
 import { showImagePreview } from './components/ImagePreview.js';
+import { renderCallsPanel } from './components/CallsPanel.js';
 import { exportUrl, EXPORT_ALL_URL, downloadFile } from './lib/export.js';
 import { copyText } from './lib/utils.js';
 
@@ -464,9 +465,12 @@ async function init() {
   // ── Wire nav rail ──────────────────────────────────
 
   const navRail = renderNavRail(container, {
+    onCalls: () => router.navigate('calls'),
     avatarSrc: '/assets/avatar-dv.jpg',
     onSettings: openSettings,
     onChat: () => {
+      // From the calls screen, this is the way back to the list.
+      if (router.getCurrentRoute().route === 'calls') { router.navigate('home'); return; }
       closeProfile();
       closeSettings();
     },
@@ -483,6 +487,8 @@ async function init() {
     onProfile: openProfile,
     onAbout: openSettings,
     onExportAll: () => downloadFile(EXPORT_ALL_URL),
+    onCalls: () => router.navigate('calls'),
+    onChats: () => router.navigate('home'),
     onSelect: (id) => {
       // Close profile/settings if open before navigating
       closeProfile();
@@ -511,7 +517,25 @@ async function init() {
   // ── Router ─────────────────────────────────────────
 
   const router = new HashRouter();
-  router.on('home', () => showEmptyState());
+  router.on('home', () => { sidebar.showChats?.(); navRail.setActive?.('chats'); showEmptyState(); });
+
+  // The calls screen takes the list's place; the log is one file, fetched
+  // the first time it is asked for.
+  let callsPromise = null;
+  router.on('calls', async () => {
+    showEmptyState();
+    callsPromise ??= fetch('/data/calls.json').then(r => r.json()).then(d => d.calls);
+    let calls = [];
+    try { calls = await callsPromise; } catch { callsPromise = null; }
+    const panel = renderCallsPanel({
+      calls,
+      conversations: store.getConversations(),
+      avatarFor: (convId) => AVATARS[convId] || null,
+      onOpen: (convId, messageId) => router.navigate('chat', convId, messageId),
+    });
+    sidebar.showCalls?.(panel);
+    navRail.setActive?.('calls');
+  });
   router.on('chat', async (id, messageId) => {
     if (messageId) {
       // Look up the date for this message ID

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -1115,3 +1115,191 @@
   opacity: 0.5;
   cursor: not-allowed;
 }
+
+/* ── Calls screen ──────────────────────────────────────────────────────────
+   Takes the chat list's place in the sidebar; the header, search and filter
+   tabs are the list's, so they step aside. */
+.sidebar--calls .sidebar-header,
+.sidebar--calls .sidebar-search,
+.sidebar--calls .sidebar-tags,
+.sidebar--calls .conversation-list {
+  display: none;
+}
+
+.calls-panel {
+  display: none;
+  flex: 1;
+  min-height: 0;
+  flex-direction: column;
+  overflow-y: auto;
+  overflow-x: hidden;
+  background: var(--WDS-white);
+}
+
+.sidebar--calls .calls-panel {
+  display: flex;
+}
+
+.calls-header {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 14px 8px 8px 16px;
+}
+
+.calls-title {
+  flex: 1;
+  margin: 0;
+  font-size: 22px;
+  font-weight: 500;
+  color: var(--WDS-content-default);
+}
+
+.calls-header-btn {
+  display: flex;
+  padding: 8px;
+  border: none;
+  background: none;
+  color: var(--WDS-content-default);
+}
+
+.calls-header-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.calls-actions {
+  display: flex;
+  justify-content: space-around;
+  padding: 8px 8px 16px;
+}
+
+.calls-action {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  border: none;
+  background: none;
+  color: var(--WDS-content-default);
+  font: inherit;
+  font-size: 13px;
+}
+
+.calls-action:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.calls-action-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background: var(--WDS-warm-gray-75);
+}
+
+.calls-recent {
+  margin: 0;
+  padding: 8px 16px;
+  font-size: 18px;
+  font-weight: 500;
+  color: var(--WDS-content-default);
+}
+
+.calls-item {
+  display: flex;
+  align-items: center;
+  padding-right: 8px;
+}
+
+.calls-item-main {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 10px 16px;
+  border: none;
+  background: none;
+  text-align: left;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+}
+
+.calls-item-main:hover,
+.calls-item-kind:hover {
+  background: var(--WDS-surface-highlight);
+}
+
+.calls-item-avatar img,
+.calls-item-avatar > svg {
+  display: block;
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  object-fit: cover;
+}
+
+.calls-item-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.calls-item-name {
+  font-size: 16px;
+  color: var(--WDS-content-default);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.calls-item.missed .calls-item-name {
+  color: #e53935;
+}
+
+.calls-item-meta {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: var(--WDS-content-deemphasized);
+}
+
+.calls-item-arrow {
+  display: flex;
+  color: var(--WDS-accent);
+}
+
+.calls-item.missed .calls-item-arrow {
+  color: #e53935;
+}
+
+.calls-item-kind {
+  display: flex;
+  padding: 12px;
+  border: none;
+  border-radius: 50%;
+  background: none;
+  color: var(--WDS-content-default);
+  cursor: pointer;
+}
+
+.calls-foot {
+  padding: 12px 16px 24px;
+  font-size: 12px;
+  color: var(--WDS-content-deemphasized);
+}
+
+.sidebar-bottom-tab {
+  border: none;
+  background: none;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+}

--- a/tests/e2e/calls.test.js
+++ b/tests/e2e/calls.test.js
@@ -1,0 +1,85 @@
+import { test, expect } from '@playwright/test';
+
+// The Calls screen is a record, not a phone: every call the material holds,
+// newest first, and a tap goes to the message where that call is.
+
+const openCalls = async (page) => {
+  await page.goto('/#/calls');
+  await expect(page.locator('.calls-panel')).toBeVisible();
+  await expect(page.locator('.calls-item').first()).toBeVisible({ timeout: 20000 });
+};
+
+test.describe('Calls screen', () => {
+  test('lists the calls, newest first, with who called whom', async ({ page }) => {
+    await openCalls(page);
+    expect(await page.locator('.calls-item').count()).toBeGreaterThan(500);
+    const first = page.locator('.calls-item').first();
+    await expect(first.locator('.calls-item-name')).toContainText('Martha Graeff');
+    await expect(first.locator('.calls-item-arrow')).toHaveAttribute('aria-label', /Chamada (feita|recebida)/);
+    await expect(first.locator('.calls-item-meta')).toContainText('2025');
+  });
+
+  test('draws a missed incoming call in red', async ({ page }) => {
+    await openCalls(page);
+    const missed = page.locator('.calls-item.missed').first();
+    await expect(missed).toBeAttached();
+    await expect(missed.locator('.calls-item-meta')).toContainText('Perdida');
+    const color = await missed.locator('.calls-item-name').evaluate(el => getComputedStyle(el).color);
+    expect(color).toMatch(/^rgb\(229, 57, 53\)$/);
+  });
+
+  test('the buttons across the top are there and do nothing', async ({ page }) => {
+    await openCalls(page);
+    for (const label of ['Ligar', 'Agendar', 'Teclado', 'Favoritos', 'Pesquisar chamadas', 'Menu']) {
+      await expect(page.locator(`.calls-panel button[aria-label="${label}"]`)).toBeDisabled();
+    }
+  });
+
+  test('tapping a call opens the conversation at that call', async ({ page }) => {
+    await openCalls(page);
+    const row = page.locator('.calls-item[data-conversation="fabio-faria"][data-message="134"]');
+    await row.scrollIntoViewIfNeeded();
+    await row.locator('.calls-item-main').click();
+    await expect(page).toHaveURL(/#\/chat\/fabio-faria\/msg\/134$/);
+    await expect(page.locator('.chat-msg-row[data-id="134"]')).toBeVisible({ timeout: 20000 });
+    await expect(page.locator('.chat-msg-row[data-id="134"] .chat-call-label')).toContainText('04:34');
+  });
+
+  test('the phone icon at the right does the same', async ({ page }) => {
+    await openCalls(page);
+    const row = page.locator('.calls-item[data-conversation="fabio-faria"][data-message="88"]');
+    await row.scrollIntoViewIfNeeded();
+    await row.locator('.calls-item-kind').click();
+    await expect(page).toHaveURL(/#\/chat\/fabio-faria\/msg\/88$/);
+    await expect(page.locator('.chat-msg-row[data-id="88"]')).toBeVisible({ timeout: 20000 });
+  });
+
+  test('folds consecutive calls with the same person on the same day', async ({ page }) => {
+    await openCalls(page);
+    await expect(page.locator('.calls-item-name', { hasText: /\(\d+\)$/ }).first()).toBeAttached();
+  });
+});
+
+test.describe('Getting there', () => {
+  test('from the Chamadas tab, and back to the list from Conversas', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.locator('.conversation-item').first()).toBeVisible();
+    const isMobile = page.viewportSize().width <= 600;
+    if (isMobile) {
+      await page.locator('.sidebar-bottom-tab[data-tab="calls"]').click();
+    } else {
+      await page.locator('.nav-rail button[aria-label="Chamadas"], button[aria-label="Chamadas"]').first().click();
+    }
+    await expect(page).toHaveURL(/#\/calls$/);
+    await expect(page.locator('.calls-panel')).toBeVisible();
+    await expect(page.locator('.conversation-list')).toBeHidden();
+
+    if (isMobile) {
+      await page.locator('.sidebar-bottom-tab[data-tab="chats"]').click();
+    } else {
+      await page.locator('button[aria-label="Conversas"]').first().click();
+    }
+    await expect(page.locator('.conversation-list')).toBeVisible();
+    await expect(page.locator('.calls-panel')).toBeHidden();
+  });
+});

--- a/tests/unit/calls-data.test.js
+++ b/tests/unit/calls-data.test.js
@@ -1,0 +1,52 @@
+// @vitest-environment node
+//
+// The call log the build writes. Two grammars go in — the Martha export's
+// English, the police report's Portuguese — and one record comes out.
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const ROOT = join(import.meta.dirname, '../..');
+const calls = JSON.parse(readFileSync(join(ROOT, 'public/data/calls.json'), 'utf-8')).calls;
+const conversations = JSON.parse(readFileSync(join(ROOT, 'public/data/conversations.json'), 'utf-8')).conversations;
+
+describe('calls.json', () => {
+  it('holds every call from both sources', () => {
+    expect(calls.length).toBeGreaterThan(1300);
+    expect(new Set(calls.map(c => c.conversation_id)).size).toBeGreaterThan(5);
+  });
+
+  it('is newest first', () => {
+    const stamps = calls.map(c => c.timestamp);
+    expect(stamps).toEqual([...stamps].sort().reverse());
+  });
+
+  it('names a conversation the site has, and a message in it', () => {
+    const ids = new Set(conversations.map(c => c.id));
+    for (const c of calls) {
+      expect(ids.has(c.conversation_id), c.conversation_id).toBe(true);
+      expect(c.message_id).toBeGreaterThan(0);
+    }
+  });
+
+  it('reads the Portuguese of the report', () => {
+    const c = calls.find(x => x.conversation_id === 'fabio-faria' && x.message_id === 134);
+    expect(c).toMatchObject({ kind: 'voice', status: 'completed', duration: '04:34', outgoing: false });
+    const missed = calls.find(x => x.conversation_id === 'fabio-faria' && x.message_id === 88);
+    expect(missed).toMatchObject({ kind: 'voice', status: 'missed', outgoing: false });
+  });
+
+  it('reads the English of the export', () => {
+    const kinds = new Set(calls.map(c => c.kind));
+    expect(kinds).toEqual(new Set(['voice', 'video']));
+    const statuses = new Set(calls.map(c => c.status));
+    for (const s of ['completed', 'missed', 'no_answer', 'ended']) expect(statuses.has(s), s).toBe(true);
+    expect(calls.filter(c => c.status === 'completed' && !c.duration)).toHaveLength(0);
+  });
+
+  it('knows who called', () => {
+    expect(calls.some(c => c.outgoing)).toBe(true);
+    expect(calls.some(c => !c.outgoing)).toBe(true);
+  });
+});

--- a/tests/unit/calls-panel.test.js
+++ b/tests/unit/calls-panel.test.js
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { groupCalls, formatCallTime } from '../../src/components/CallsPanel.js';
+
+describe('grouping', () => {
+  const call = (o) => ({ conversation_id: 'a', date: '2025-01-01', outgoing: true, status: 'completed', message_id: 1, timestamp: '2025-01-01T10:00:00', ...o });
+
+  it('folds consecutive calls with the same person on the same day', () => {
+    const rows = groupCalls([call({ message_id: 3 }), call({ message_id: 2 }), call({ message_id: 1, date: '2024-12-31' })]);
+    expect(rows.map(r => [r.call.message_id, r.count])).toEqual([[3, 2], [1, 1]]);
+  });
+
+  it('keeps a missed call apart from an answered one', () => {
+    const rows = groupCalls([call({ message_id: 2, status: 'missed', outgoing: false }), call({ message_id: 1 })]);
+    expect(rows).toHaveLength(2);
+  });
+
+  it('keeps different people apart', () => {
+    expect(groupCalls([call({ conversation_id: 'a' }), call({ conversation_id: 'b' })])).toHaveLength(2);
+  });
+});
+
+describe('formatCallTime', () => {
+  it('reads like the phone: day, month, year, time', () => {
+    expect(formatCallTime('2024-07-16T21:12:05')).toMatch(/^16 de jul\.? de 2024, 21:12$/);
+  });
+});


### PR DESCRIPTION
O material registra **1.335 chamadas**: 1.322 no export da Martha, em inglês ("Voice call, 3 min", "Missed video call, Tap to call back", "Voice call, No answer"), e 13 no laudo da PF, em português ("Chamada de voz — duração 02:49", "Chamada de voz perdida"). O build lê as duas gramáticas e escreve `public/data/calls.json` com direção, tipo, como terminou e duração, mais recente primeiro.

## A tela

Como a referência: os botões do topo (Ligar, Agendar, Teclado, Favoritos, busca, menu) estão lá e **desabilitados** — isto é um registro, não um telefone. "Recentes" lista cada chamada com foto, nome, a seta de quem ligou pra quem (**vermelha** quando entrou e não foi atendida), data, hora e duração, e o ícone de voz ou vídeo à direita. Chamadas seguidas com a mesma pessoa no mesmo dia dobram numa linha com "(n)". **Tocar na linha ou no ícone abre a conversa na mensagem onde a chamada está.**

Rota `#/calls`. A aba Chamadas do rodapé (mobile) e o ícone do NavRail (desktop) funcionam; Conversas volta pra lista. O painel toma o lugar da lista na sidebar.

## Testes

- `calls-data.test.js`: as duas gramáticas, ordem, toda chamada numa conversa que existe
- `calls-panel.test.js`: agrupamento e formato de data
- `calls.test.js` (E2E, desktop e mobile): lista, vermelho da perdida, botões desabilitados, clique na linha e no ícone chegando à mensagem certa, ida e volta pelas abas

231 → 238 unit; 275 E2E (+14). Independente do #21 (mídia) — os dois saem de `main`; se um conflitar no `main.js` depois do outro, eu rebaseio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RPgDUnTk2JuejAso8UHMWb