### PR TITLE
Contatos compartilhados abrem como diálogo no desktop, como no WhatsApp Web

### DIFF
--- a/src/components/ContactsSheet.js
+++ b/src/components/ContactsSheet.js
@@ -13,6 +13,7 @@
 import { defaultAvatarSvg } from '../lib/avatar.js';
 import { conversationForPhone } from '../lib/media.js';
 
+const ICON_CLOSE = `<svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>`;
 const ICON_BACK = `<svg viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M19 12H5"/><path d="m12 19-7-7 7-7"/></svg>`;
 export const ICON_MESSAGE = `<svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>`;
 export const ICON_CALL = `<svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M22 16.92v3a2 2 0 0 1-2.18 2 19.79 19.79 0 0 1-8.63-3.07 19.5 19.5 0 0 1-6-6 19.79 19.79 0 0 1-3.07-8.67A2 2 0 0 1 4.11 2h3a2 2 0 0 1 2 1.72c.13.96.36 1.9.7 2.81a2 2 0 0 1-.45 2.11L8.09 9.91a16 16 0 0 0 6 6l1.27-1.27a2 2 0 0 1 2.11-.45c.91.34 1.85.57 2.81.7A2 2 0 0 1 22 16.92z"/></svg>`;
@@ -37,8 +38,9 @@ export function showContactsSheet(container, contacts, { conversations, avatarFo
   bar.className = 'contacts-sheet-bar';
   const back = document.createElement('button');
   back.className = 'contacts-sheet-back';
-  back.setAttribute('aria-label', 'Voltar');
-  back.innerHTML = ICON_BACK;
+  back.setAttribute('aria-label', 'Fechar');
+  // A back arrow on the phone, an X on the web; CSS shows one per width.
+  back.innerHTML = `<span class="is-back">${ICON_BACK}</span><span class="is-close">${ICON_CLOSE}</span>`;
   bar.appendChild(back);
   const title = document.createElement('span');
   title.className = 'contacts-sheet-title';
@@ -60,6 +62,9 @@ export function showContactsSheet(container, contacts, { conversations, avatarFo
   function onKeydown(e) { if (e.key === 'Escape') close(); }
   back.addEventListener('click', close);
   document.addEventListener('keydown', onKeydown, true);
+  // On a wide screen the sheet is a dialog over a dimmed chat; clicking the
+  // dim closes it. On the phone it fills the screen and there is nothing to hit.
+  sheet.addEventListener('click', (e) => { if (e.target === sheet) close(); });
 
   container.appendChild(sheet);
   return { element: sheet, close };

--- a/src/styles/components.css
+++ b/src/styles/components.css
@@ -1303,3 +1303,41 @@
   color: inherit;
   cursor: pointer;
 }
+
+/* On a wide screen WhatsApp Web opens shared contacts as a centred dialog
+   over the chat, not as a page; the phone keeps the full screen. */
+@media (min-width: 601px) {
+  .contacts-sheet {
+    background: rgba(17, 27, 33, 0.55);
+    align-items: center;
+    justify-content: center;
+  }
+
+  .contacts-sheet-bar,
+  .contacts-sheet-list {
+    width: min(480px, calc(100vw - 48px));
+    background: var(--WDS-white);
+  }
+
+  .contacts-sheet-bar {
+    border-radius: 12px 12px 0 0;
+    box-sizing: border-box;
+  }
+
+  .contacts-sheet-list {
+    flex: 0 1 auto;
+    max-height: 70vh;
+    border-radius: 0 0 12px 12px;
+    box-sizing: border-box;
+  }
+
+  .contacts-sheet-item:last-child {
+    margin-bottom: 0;
+  }
+}
+
+.contacts-sheet-back .is-close { display: none; }
+@media (min-width: 601px) {
+  .contacts-sheet-back .is-back { display: none; }
+  .contacts-sheet-back .is-close { display: flex; }
+}

--- a/tests/e2e/media-fidelity.test.js
+++ b/tests/e2e/media-fidelity.test.js
@@ -73,6 +73,22 @@ test.describe('Contact cards', () => {
     await expect(page.locator('.contacts-sheet')).toHaveCount(0);
   });
 
+  // WhatsApp Web shows shared contacts in a dialog over the chat; the phone
+  // takes the whole screen.
+  test('on a wide screen the list is a dialog over the chat, closed by clicking outside', async ({ page }) => {
+    test.skip(page.viewportSize().width <= 600, 'phone: full screen by design');
+    const row = await open(page, 'fabio-faria', 19);
+    await row.locator('.chat-contact-action', { hasText: 'Ver todos' }).click();
+    const sheet = page.locator('.contacts-sheet');
+    const list = await sheet.locator('.contacts-sheet-list').boundingBox();
+    const view = page.viewportSize();
+    expect(list.width).toBeLessThan(view.width * 0.6);
+    expect(list.x).toBeGreaterThan(view.width * 0.2);
+    await expect(page.locator('.chat-header')).toBeVisible();
+    await page.mouse.click(10, view.height - 10);
+    await expect(sheet).toHaveCount(0);
+  });
+
   test('the sheet closes on its back button', async ({ page }) => {
     const row = await open(page, 'fabio-faria', 19);
     await row.locator('.chat-contact-action', { hasText: 'Ver todos' }).click();


### PR DESCRIPTION
"Ver todos" abria a lista em tela cheia nos dois layouts. Tela cheia é o celular; na web o WhatsApp abre um **diálogo centralizado** sobre o chat escurecido, com X, que fecha clicando fora ou no Esc. Agora é assim acima de 600px; abaixo continua a tela cheia com a seta de voltar.

Só CSS por breakpoint e um listener de clique no fundo. Teste no desktop mede o diálogo (largura, posição, chat visível atrás) e o fecha clicando fora; no mobile o teste é pulado por desenho.

254 unit, 298 E2E.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RPgDUnTk2JuejAso8UHMWb